### PR TITLE
Fix bertrand pillar mapping for letsencrypt

### DIFF
--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -7,7 +7,7 @@ base:
   - hosts.bela
   'bertone.batlogg.com':
   - hosts.bertone
-  'bertone.batlogg.com':
-  - hosts.bertone
+  'bertrand.batlogg.com':
+  - hosts.bertrand
   'janos.a1.nr.gy':
   - hosts.janos


### PR DESCRIPTION
Add missing pillar top mapping for bertrand.batlogg.com so hosts.bertrand is loaded and letsencrypt pillar keys are present during render. This fixes the salt-call failure in letsencrypt/init.sls.