### PR TITLE
Letsencrypt: fix Ubuntu config paths and nginx default.d dir

### DIFF
--- a/salt/letsencrypt/init.sls
+++ b/salt/letsencrypt/init.sls
@@ -1,6 +1,12 @@
 certbot:
   pkg.installed: []
 
+{%- if grains['os_family'] == 'RedHat' %}
+  {%- set certbot_config_path = '/etc/sysconfig/certbot' %}
+{%- else %}
+  {%- set certbot_config_path = '/etc/default/certbot' %}
+{%- endif %}
+
 letsencrypt:
   group.present:
   - system: true
@@ -48,7 +54,7 @@ letsencrypt:
   - group: letsencrypt
 {%- endfor %}
 
-/etc/sysconfig/certbot:
+{{ certbot_config_path }}:
   file.managed:
   - source: salt://letsencrypt/certbot.sysconfig.j2
   - template: jinja

--- a/salt/letsencrypt/nginx.sls
+++ b/salt/letsencrypt/nginx.sls
@@ -4,6 +4,12 @@
   - name: /usr/bin/openssl dhparam -out /etc/ssl/certs/dhparam.pem 2048
   - unless: test -r /etc/ssl/certs/dhparam.pem
 
+/etc/nginx/default.d:
+  file.directory:
+  - user: root
+  - group: root
+  - dir_mode: "0755"
+
 /etc/nginx/default.d/letsencrypt.conf:
   file.managed:
   - source: salt://letsencrypt/letsencrypt.conf


### PR DESCRIPTION
Fixes two runtime issues on bertrand: use /etc/default/certbot on non-RedHat systems, and ensure /etc/nginx/default.d exists before managing letsencrypt include files.