### PR TITLE
Bertrand: restore apex/www cert domains and add www redirect

### DIFF
--- a/pillar/hosts/bertrand.sls
+++ b/pillar/hosts/bertrand.sls
@@ -2,6 +2,8 @@ letsencrypt:
   mode: nginx
   certs:
     namche.ai:
+    - namche.ai
+    - www.namche.ai
     - api.namche.ai
     - nima.namche.ai
     - pema.namche.ai

--- a/salt/bertrand/namche.ai.conf
+++ b/salt/bertrand/namche.ai.conf
@@ -1,6 +1,20 @@
 server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
+    server_name www.namche.ai;
+
+    ssl_certificate /etc/letsencrypt/live/namche.ai/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/namche.ai/privkey.pem;
+    ssl_trusted_certificate /etc/letsencrypt/live/namche.ai/chain.pem;
+    include conf.d/ssl.conf.inc;
+    include conf.d/letsencrypt.conf.inc;
+
+    return 301 https://namche.ai$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
     server_name api.namche.ai;
     client_max_body_size 50M;
 


### PR DESCRIPTION
## Summary
- re-add  and  to bertrand letsencrypt cert domains
- add dedicated TLS server block to redirect  to 
- keep existing wildcard/static and api proxy behavior unchanged
