### PR TITLE
Bertrand: route api.namche.ai to local API proxy on port 3000

### DIFF
--- a/salt/bertrand/namche.ai.conf
+++ b/salt/bertrand/namche.ai.conf
@@ -30,16 +30,18 @@ server {
     ssl_trusted_certificate /etc/nginx/certs/cloudflare-origin-ca-rsa-root.pem;
     include conf.d/ssl.conf.inc;
 
-    location ~ ^/webhooks/agent/(?<agent>[a-zA-Z0-9_-]+)/(?<hook_path>.+)$ {
-        proxy_ssl_server_name on;
-        proxy_set_header Host $agent.khumbu.namche.ai;
+    location / {
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_pass https://$agent.khumbu.namche.ai:8443/api/webhooks/$hook_path$is_args$args;
-    }
-
-    location / {
-        return 404;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header X-Original-URI $request_uri;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_pass http://127.0.0.1:3000;
     }
 
     access_log /var/log/nginx/api.namche.ai.access.log;


### PR DESCRIPTION
Update nginx for api.namche.ai to forward all requests to the local Hono API proxy on 127.0.0.1:3000 and set standard forwarding headers (Host, X-Real-IP, X-Forwarded-*, Upgrade/Connection).