### PR TITLE
Common: add tashi user with SSH key and salt-call sudo

### DIFF
--- a/salt/common/admin.sls
+++ b/salt/common/admin.sls
@@ -3,3 +3,44 @@
     - user: admin
     - group: admin
     - mode: "0775"
+
+tashi:
+  user.present:
+    - shell: /bin/bash
+    - home: /home/tashi
+    - createhome: True
+
+/home/tashi/.ssh:
+  file.directory:
+    - user: tashi
+    - group: tashi
+    - mode: "0700"
+    - require:
+      - user: tashi
+
+/home/tashi/.ssh/authorized_keys:
+  file.managed:
+    - user: tashi
+    - group: tashi
+    - mode: "0600"
+    - contents: |
+        ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKTqdskP8o1MPc2tGkXM8VwshE1BeyzRH0vdLSwn/POs tashi@batlogg.com
+    - require:
+      - file: /home/tashi/.ssh
+
+/etc/sudoers.d:
+  file.directory:
+    - user: root
+    - group: root
+    - mode: "0750"
+
+/etc/sudoers.d/tashi-salt-call:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: "0440"
+    - contents: |
+        tashi ALL=(root) NOPASSWD: /usr/bin/salt-call, /opt/saltstack/salt/bin/salt-call
+    - check_cmd: /usr/sbin/visudo -cf
+    - require:
+      - file: /etc/sudoers.d


### PR DESCRIPTION
Adds user  in common admin state, installs this machine's ed25519 public key into , and adds  to allow passwordless sudo for salt-call binaries only.