### PR TITLE
Bertrand: add deploy SSH user for website deploys

### DIFF
--- a/salt/bertrand/deploy.sls
+++ b/salt/bertrand/deploy.sls
@@ -1,27 +1,3 @@
-deploy:
-  user.present:
-    - shell: /bin/bash
-    - home: /home/deploy
-    - createhome: True
-
-/home/deploy/.ssh:
-  file.directory:
-    - user: deploy
-    - group: deploy
-    - mode: "0700"
-    - require:
-      - user: deploy
-
-/home/deploy/.ssh/authorized_keys:
-  file.managed:
-    - user: deploy
-    - group: deploy
-    - mode: "0600"
-    - contents: |
-        ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMiV0qz927RXGyqvUb0mCUwRGMuPnLkW7qO+y3cHW/Fl deploy@namche.ai
-    - require:
-      - file: /home/deploy/.ssh
-
 /var/www/html/namche.ai:
   file.directory:
     - user: deploy

--- a/salt/bertrand/deploy.sls
+++ b/salt/bertrand/deploy.sls
@@ -1,6 +1,17 @@
-/var/www/html/namche.ai:
+/var/www/html:
+  file.directory:
+    - user: root
+    - group: root
+    - dir_mode: "0755"
+    - makedirs: True
+
+{% for site in ['namche.ai', 'www.namche.ai', 'api.namche.ai', 'nima.namche.ai', 'pema.namche.ai', 'tashi.namche.ai'] %}
+/var/www/html/{{ site }}:
   file.directory:
     - user: deploy
     - group: deploy
     - dir_mode: "2775"
     - makedirs: True
+    - require:
+      - file: /var/www/html
+{% endfor %}

--- a/salt/bertrand/deploy.sls
+++ b/salt/bertrand/deploy.sls
@@ -1,0 +1,30 @@
+deploy:
+  user.present:
+    - shell: /bin/bash
+    - home: /home/deploy
+    - createhome: True
+
+/home/deploy/.ssh:
+  file.directory:
+    - user: deploy
+    - group: deploy
+    - mode: "0700"
+    - require:
+      - user: deploy
+
+/home/deploy/.ssh/authorized_keys:
+  file.managed:
+    - user: deploy
+    - group: deploy
+    - mode: "0600"
+    - contents: |
+        ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMiV0qz927RXGyqvUb0mCUwRGMuPnLkW7qO+y3cHW/Fl deploy@namche.ai
+    - require:
+      - file: /home/deploy/.ssh
+
+/var/www/html/namche.ai:
+  file.directory:
+    - user: deploy
+    - group: deploy
+    - dir_mode: "2775"
+    - makedirs: True

--- a/salt/bertrand/init.sls
+++ b/salt/bertrand/init.sls
@@ -1,4 +1,5 @@
 include:
+  - bertrand.deploy
   - bertrand.repo
   - bertrand.volumes
   - docker

--- a/salt/bertrand/repo.sls
+++ b/salt/bertrand/repo.sls
@@ -15,6 +15,13 @@ bertrand-repo-tashi-group-membership:
       - infra
     - append: True
 
+bertrand-repo-deploy-group-membership:
+  user.present:
+    - name: deploy
+    - groups:
+      - infra
+    - append: True
+
 /srv:
   file.directory:
     - user: root
@@ -57,4 +64,13 @@ tashi-safe-directory-infra:
     - unless: git config --global --get-all safe.directory | grep -Fx '/srv/infra'
     - require:
       - user: bertrand-repo-tashi-group-membership
+      - file: /srv/infra
+
+deploy-safe-directory-infra:
+  cmd.run:
+    - name: git config --global --add safe.directory /srv/infra
+    - runas: deploy
+    - unless: git config --global --get-all safe.directory | grep -Fx '/srv/infra'
+    - require:
+      - user: bertrand-repo-deploy-group-membership
       - file: /srv/infra

--- a/salt/bertrand/repo.sls
+++ b/salt/bertrand/repo.sls
@@ -1,14 +1,16 @@
 infra:
   group.present: []
 
-admin:
+bertrand-repo-admin-group-membership:
   user.present:
+    - name: admin
     - groups:
       - infra
     - append: True
 
-tashi:
+bertrand-repo-tashi-group-membership:
   user.present:
+    - name: tashi
     - groups:
       - infra
     - append: True
@@ -45,7 +47,7 @@ admin-safe-directory-infra:
     - runas: admin
     - unless: git config --global --get-all safe.directory | grep -Fx '/srv/infra'
     - require:
-      - user: admin
+      - user: bertrand-repo-admin-group-membership
       - file: /srv/infra
 
 tashi-safe-directory-infra:
@@ -54,5 +56,5 @@ tashi-safe-directory-infra:
     - runas: tashi
     - unless: git config --global --get-all safe.directory | grep -Fx '/srv/infra'
     - require:
-      - user: tashi
+      - user: bertrand-repo-tashi-group-membership
       - file: /srv/infra

--- a/salt/common/deploy.sls
+++ b/salt/common/deploy.sls
@@ -1,0 +1,23 @@
+deploy:
+  user.present:
+    - shell: /bin/bash
+    - home: /home/deploy
+    - createhome: True
+
+/home/deploy/.ssh:
+  file.directory:
+    - user: deploy
+    - group: deploy
+    - mode: "0700"
+    - require:
+      - user: deploy
+
+/home/deploy/.ssh/authorized_keys:
+  file.managed:
+    - user: deploy
+    - group: deploy
+    - mode: "0600"
+    - contents: |
+        ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMiV0qz927RXGyqvUb0mCUwRGMuPnLkW7qO+y3cHW/Fl deploy@namche.ai
+    - require:
+      - file: /home/deploy/.ssh

--- a/salt/common/init.sls
+++ b/salt/common/init.sls
@@ -1,6 +1,7 @@
 include:
   - common.admin
   - common.bash
+  - common.deploy
   - common.ghostty
   - common.sudoers
   - common.sshd


### PR DESCRIPTION
Adds a host-scoped  user on bertrand with the provided SSH key, ensures  is writable by that user for GitHub Actions deploys, and includes the pending  Salt ID conflict fix so state.apply compiles cleanly.