### PR TITLE
ci: fallback DEPLOY_USER to deploy

### DIFF
--- a/.github/workflows/bertrand-apply.yml
+++ b/.github/workflows/bertrand-apply.yml
@@ -25,10 +25,5 @@ jobs:
 
       - name: Pull and apply Salt on bertrand
         run: |
-          DEPLOY_USER="${{ vars.DEPLOY_USER }}"
-          if [ -z "$DEPLOY_USER" ]; then
-            DEPLOY_USER="deploy"
-          fi
-
-          ssh -o IdentitiesOnly=yes -o IdentityAgent=none -i ~/.ssh/id_ed25519 "${DEPLOY_USER}@bertrand" \
+          ssh -o IdentitiesOnly=yes -o IdentityAgent=none -i ~/.ssh/id_ed25519 "deploy@bertrand" \
             'cd /srv/infra && git pull && sudo -n salt-call --local state.apply terse=true'

--- a/.github/workflows/bertrand-apply.yml
+++ b/.github/workflows/bertrand-apply.yml
@@ -25,5 +25,10 @@ jobs:
 
       - name: Pull and apply Salt on bertrand
         run: |
-          ssh -o IdentitiesOnly=yes -o IdentityAgent=none -i ~/.ssh/id_ed25519 "${{ vars.DEPLOY_USER }}@bertrand" \
+          DEPLOY_USER="${{ vars.DEPLOY_USER }}"
+          if [ -z "$DEPLOY_USER" ]; then
+            DEPLOY_USER="deploy"
+          fi
+
+          ssh -o IdentitiesOnly=yes -o IdentityAgent=none -i ~/.ssh/id_ed25519 "${DEPLOY_USER}@bertrand" \
             'cd /srv/infra && git pull && sudo -n salt-call --local state.apply terse=true'


### PR DESCRIPTION
Fixes failed Bertrand Salt Apply run after merge.\n\nRoot cause: DEPLOY_USER variable was empty, producing an invalid ssh destination (@bertrand).\n\nChange:\n- Default DEPLOY_USER to deploy when vars.DEPLOY_USER is unset.