### PR TITLE
ci: use bertrand FQDN in apply workflow

### DIFF
--- a/.github/workflows/bertrand-apply.yml
+++ b/.github/workflows/bertrand-apply.yml
@@ -25,5 +25,5 @@ jobs:
 
       - name: Pull and apply Salt on bertrand
         run: |
-          ssh -o IdentitiesOnly=yes -o IdentityAgent=none -i ~/.ssh/id_ed25519 "deploy@bertrand" \
+          ssh -o IdentitiesOnly=yes -o IdentityAgent=none -i ~/.ssh/id_ed25519 "deploy@bertrand.batlogg.com" \
             'cd /srv/infra && git pull && sudo -n salt-call --local state.apply terse=true'


### PR DESCRIPTION
Fix failed run where GitHub runner could not resolve short hostname 'bertrand'.\n\nChange:\n- Use deploy@bertrand.batlogg.com as SSH target in Bertrand Salt Apply workflow.