### PR TITLE
ci: use explicit salt-call path for sudo

### DIFF
--- a/.github/workflows/bertrand-apply.yml
+++ b/.github/workflows/bertrand-apply.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Pull and apply Salt on bertrand
         run: |
           ssh -o IdentitiesOnly=yes -o IdentityAgent=none -i ~/.ssh/id_ed25519 "deploy@bertrand.batlogg.com" \
-            'cd /srv/infra && git pull && sudo -n salt-call --local state.apply terse=true'
+            'cd /srv/infra && git pull && sudo -n /opt/saltstack/salt/bin/salt-call --local state.apply terse=true'

--- a/.github/workflows/bertrand-apply.yml
+++ b/.github/workflows/bertrand-apply.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Pull and apply Salt on bertrand
         run: |
           ssh -o IdentitiesOnly=yes -o IdentityAgent=none -i ~/.ssh/id_ed25519 "deploy@bertrand.batlogg.com" \
-            'cd /srv/infra && git pull && sudo -n /opt/saltstack/salt/bin/salt-call --local state.apply terse=true'
+            'cd /srv/infra && git pull && sudo -n /usr/bin/salt-call --local state.apply terse=true'

--- a/salt/common/bash.sls
+++ b/salt/common/bash.sls
@@ -36,3 +36,30 @@
         }
 
         PROMPT_COMMAND=prompt_command
+
+# Ghostty
+ncurses-bin:
+  pkg.installed: []
+
+/usr/local/share/terminfo:
+  file.directory:
+  - user: root
+  - group: root
+  - dir_mode: "0755"
+
+/usr/local/share/terminfo/xterm-ghostty.src:
+  file.managed:
+  - source: salt://common/xterm-ghostty.src
+  - user: root
+  - group: root
+  - mode: "0644"
+  - require:
+    - file: /usr/local/share/terminfo
+
+xterm-ghostty-terminfo:
+  cmd.run:
+  - name: tic -x -o /usr/share/terminfo /usr/local/share/terminfo/xterm-ghostty.src
+  - unless: test -e /usr/share/terminfo/78/xterm-ghostty -o -e /lib/terminfo/78/xterm-ghostty
+  - require:
+    - pkg: ncurses-bin
+    - file: /usr/local/share/terminfo/xterm-ghostty.src

--- a/salt/common/infra.sls
+++ b/salt/common/infra.sls
@@ -29,12 +29,6 @@ deploy:
     - require:
       - file: /home/deploy/.ssh
 
-/etc/sudoers.d:
-  file.directory:
-    - user: root
-    - group: root
-    - mode: "0750"
-
 /etc/sudoers.d/deploy-salt-call:
   file.managed:
     - user: root


### PR DESCRIPTION
Fixes deploy workflow failure where sudo requested a password.\n\nRoot cause:\n- workflow used \n- sudoers allows exact paths only ( and )\n\nChange:\n- use 