### PR TITLE
salt: fix deploy requisite recursion in highstate

### DIFF
--- a/salt/common/infra.sls
+++ b/salt/common/infra.sls
@@ -1,12 +1,13 @@
 infra:
   group.present: []
 
-deploy-user:
+deploy:
   user.present:
     - shell: /bin/bash
     - home: /home/deploy
     - optional_groups:
       - infra
+      - www-data
     - createhome: True
     - require:
       - group: infra
@@ -17,7 +18,7 @@ deploy-user:
     - group: deploy
     - mode: "0700"
     - require:
-      - user: deploy-user
+      - user: deploy
 
 /home/deploy/.ssh/authorized_keys:
   file.managed:

--- a/salt/common/infra.sls
+++ b/salt/common/infra.sls
@@ -1,7 +1,7 @@
 infra:
   group.present: []
 
-deploy:
+deploy-user:
   user.present:
     - shell: /bin/bash
     - home: /home/deploy
@@ -17,7 +17,7 @@ deploy:
     - group: deploy
     - mode: "0700"
     - require:
-      - user: deploy
+      - user: deploy-user
 
 /home/deploy/.ssh/authorized_keys:
   file.managed:

--- a/salt/common/salt.sls
+++ b/salt/common/salt.sls
@@ -15,7 +15,7 @@ salt-minion:
     - mode: "2775"
     - require:
       - file: /srv
-      - user: deploy-user
+      - user: deploy
       - group: infra
 
 normalize-srv-infra-perms:
@@ -35,5 +35,5 @@ deploy-safe-directory-srv-infra:
     - runas: deploy
     - unless: git config --global --get-all safe.directory | grep -Fx '/srv/infra'
     - require:
-      - user: deploy-user
+      - user: deploy
       - file: /srv/infra

--- a/salt/common/salt.sls
+++ b/salt/common/salt.sls
@@ -15,7 +15,7 @@ salt-minion:
     - mode: "2775"
     - require:
       - file: /srv
-      - user: deploy
+      - user: deploy-user
       - group: infra
 
 normalize-srv-infra-perms:
@@ -35,5 +35,5 @@ deploy-safe-directory-srv-infra:
     - runas: deploy
     - unless: git config --global --get-all safe.directory | grep -Fx '/srv/infra'
     - require:
-      - user: deploy
+      - user: deploy-user
       - file: /srv/infra

--- a/salt/nginx/init.sls
+++ b/salt/nginx/init.sls
@@ -23,7 +23,7 @@ deploy-www-data-group-membership:
     - optional_groups:
       - www-data
     - require:
-      - user: deploy
+      - user: deploy-user
 
 nginx-reload-base:
   cmd.run:

--- a/salt/nginx/init.sls
+++ b/salt/nginx/init.sls
@@ -17,13 +17,12 @@ nginx:
     - dir_mode: "2775"
     - makedirs: True
 
-deploy-www-data-group-membership:
-  user.present:
-    - name: deploy
-    - optional_groups:
-      - www-data
+www-data:
+  group.present:
+    - addusers:
+      - deploy
     - require:
-      - user: deploy-user
+      - user: deploy
 
 nginx-reload-base:
   cmd.run:


### PR DESCRIPTION
Fixes highstate failure with "Recursive requisite found" on deploy group membership.\n\nCause:\n- Multiple  states for deploy used ambiguous .\n\nChange:\n- Rename deploy user state ID in common to .\n- Point cross-module requisites to  explicitly in:\n  - \n  - \n\nThis removes recursive/ambiguous requisite resolution while keeping intended ownership and group membership behavior.