### PR TITLE
common: fix ghostty terminfo header compatibility

### DIFF
--- a/salt/common/xterm-ghostty.src
+++ b/salt/common/xterm-ghostty.src
@@ -1,5 +1,5 @@
 #	Reconstructed via infocmp from file: /Users/tashi/.terminfo/78/xterm-ghostty
-xterm-ghostty|ghostty|Ghostty,
+xterm-ghostty|Ghostty terminal emulator,
 	am, bce, ccc, hs, km, mc5i, mir, msgr, npc, xenl, AX, Su, Tc, XT, fullkbd,
 	colors#256, cols#80, it#8, lines#24, pairs#32767,
 	acsc=++, bel=^G, blink=\E[5m, bold=\E[1m, cbt=\E[Z,


### PR DESCRIPTION
Adjust xterm-ghostty terminfo header to avoid older tic parsing warning about description vs alias field.