### PR TITLE
ci: serialize Bertrand Salt Apply workflow runs

### DIFF
--- a/.github/workflows/bertrand-apply.yml
+++ b/.github/workflows/bertrand-apply.yml
@@ -6,6 +6,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: bertrand-salt-apply
+  cancel-in-progress: false
+
 jobs:
   apply:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes intermittent failure when two merges trigger overlapping deploy runs and the second run hits Salt lock ().\n\nChange:\n- add workflow concurrency group \n- set  so runs are queued, not cancelled