### PR TITLE
salt: make noisy cmd states idempotent

### DIFF
--- a/salt/common/bash.sls
+++ b/salt/common/bash.sls
@@ -58,19 +58,12 @@ ncurses-bin:
 
 xterm-ghostty-terminfo:
   cmd.run:
-  - name: |
+  - name: tic -x -o /usr/share/terminfo /usr/local/share/terminfo/xterm-ghostty.src
+  - unless: |
       src=/usr/local/share/terminfo/xterm-ghostty.src
       out=/usr/share/terminfo/78/xterm-ghostty
       alt=/lib/terminfo/78/xterm-ghostty
-
-      if { [ -e "$out" ] && [ "$out" -nt "$src" ]; } || { [ -e "$alt" ] && [ "$alt" -nt "$src" ]; }; then
-        echo "changed=no comment='xterm-ghostty terminfo already up to date'"
-        exit 0
-      fi
-
-      tic -x -o /usr/share/terminfo "$src"
-      echo "changed=yes comment='compiled xterm-ghostty terminfo'"
-  - stateful: True
+      { [ -e "$out" ] && [ "$out" -nt "$src" ]; } || { [ -e "$alt" ] && [ "$alt" -nt "$src" ]; }
   - require:
     - pkg: ncurses-bin
     - file: /usr/local/share/terminfo/xterm-ghostty.src

--- a/salt/common/bash.sls
+++ b/salt/common/bash.sls
@@ -58,8 +58,19 @@ ncurses-bin:
 
 xterm-ghostty-terminfo:
   cmd.run:
-  - name: tic -x -o /usr/share/terminfo /usr/local/share/terminfo/xterm-ghostty.src
-  - unless: test -e /usr/share/terminfo/78/xterm-ghostty -o -e /lib/terminfo/78/xterm-ghostty
+  - name: |
+      src=/usr/local/share/terminfo/xterm-ghostty.src
+      out=/usr/share/terminfo/78/xterm-ghostty
+      alt=/lib/terminfo/78/xterm-ghostty
+
+      if { [ -e "$out" ] && [ "$out" -nt "$src" ]; } || { [ -e "$alt" ] && [ "$alt" -nt "$src" ]; }; then
+        echo "changed=no comment='xterm-ghostty terminfo already up to date'"
+        exit 0
+      fi
+
+      tic -x -o /usr/share/terminfo "$src"
+      echo "changed=yes comment='compiled xterm-ghostty terminfo'"
+  - stateful: True
   - require:
     - pkg: ncurses-bin
     - file: /usr/local/share/terminfo/xterm-ghostty.src

--- a/salt/common/bash.sls
+++ b/salt/common/bash.sls
@@ -59,7 +59,7 @@ ncurses-bin:
 xterm-ghostty-terminfo:
   cmd.run:
   - name: tic -x -o /usr/share/terminfo /usr/local/share/terminfo/xterm-ghostty.src
-  - unless: test -e /usr/share/terminfo/78/xterm-ghostty -o -e /lib/terminfo/78/xterm-ghostty
+  - unless: test -e /usr/share/terminfo/x/xterm-ghostty -o -e /lib/terminfo/x/xterm-ghostty
   - require:
     - pkg: ncurses-bin
     - file: /usr/local/share/terminfo/xterm-ghostty.src

--- a/salt/common/bash.sls
+++ b/salt/common/bash.sls
@@ -59,16 +59,7 @@ ncurses-bin:
 xterm-ghostty-terminfo:
   cmd.run:
   - name: tic -x -o /usr/share/terminfo /usr/local/share/terminfo/xterm-ghostty.src
-  - unless: |
-      src=/usr/local/share/terminfo/xterm-ghostty.src
-      out_hex=/usr/share/terminfo/78/xterm-ghostty
-      out_chr=/usr/share/terminfo/x/xterm-ghostty
-      alt_hex=/lib/terminfo/78/xterm-ghostty
-      alt_chr=/lib/terminfo/x/xterm-ghostty
-      { [ -e "$out_hex" ] && [ "$out_hex" -nt "$src" ]; } || \
-      { [ -e "$out_chr" ] && [ "$out_chr" -nt "$src" ]; } || \
-      { [ -e "$alt_hex" ] && [ "$alt_hex" -nt "$src" ]; } || \
-      { [ -e "$alt_chr" ] && [ "$alt_chr" -nt "$src" ]; }
+  - unless: test -e /usr/share/terminfo/78/xterm-ghostty -o -e /lib/terminfo/78/xterm-ghostty
   - require:
     - pkg: ncurses-bin
     - file: /usr/local/share/terminfo/xterm-ghostty.src

--- a/salt/common/bash.sls
+++ b/salt/common/bash.sls
@@ -61,9 +61,14 @@ xterm-ghostty-terminfo:
   - name: tic -x -o /usr/share/terminfo /usr/local/share/terminfo/xterm-ghostty.src
   - unless: |
       src=/usr/local/share/terminfo/xterm-ghostty.src
-      out=/usr/share/terminfo/78/xterm-ghostty
-      alt=/lib/terminfo/78/xterm-ghostty
-      { [ -e "$out" ] && [ "$out" -nt "$src" ]; } || { [ -e "$alt" ] && [ "$alt" -nt "$src" ]; }
+      out_hex=/usr/share/terminfo/78/xterm-ghostty
+      out_chr=/usr/share/terminfo/x/xterm-ghostty
+      alt_hex=/lib/terminfo/78/xterm-ghostty
+      alt_chr=/lib/terminfo/x/xterm-ghostty
+      { [ -e "$out_hex" ] && [ "$out_hex" -nt "$src" ]; } || \
+      { [ -e "$out_chr" ] && [ "$out_chr" -nt "$src" ]; } || \
+      { [ -e "$alt_hex" ] && [ "$alt_hex" -nt "$src" ]; } || \
+      { [ -e "$alt_chr" ] && [ "$alt_chr" -nt "$src" ]; }
   - require:
     - pkg: ncurses-bin
     - file: /usr/local/share/terminfo/xterm-ghostty.src

--- a/salt/common/bash.sls
+++ b/salt/common/bash.sls
@@ -59,8 +59,11 @@ ncurses-bin:
 xterm-ghostty-terminfo:
   cmd.run:
   - name: tic -x -o /usr/share/terminfo /usr/local/share/terminfo/xterm-ghostty.src
+  - unless: |
+      src=/usr/local/share/terminfo/xterm-ghostty.src
+      out=/usr/share/terminfo/78/xterm-ghostty
+      alt=/lib/terminfo/78/xterm-ghostty
+      { [ -e "$out" ] && [ "$out" -nt "$src" ]; } || { [ -e "$alt" ] && [ "$alt" -nt "$src" ]; }
   - require:
     - pkg: ncurses-bin
-    - file: /usr/local/share/terminfo/xterm-ghostty.src
-  - onchanges:
     - file: /usr/local/share/terminfo/xterm-ghostty.src

--- a/salt/common/bash.sls
+++ b/salt/common/bash.sls
@@ -59,11 +59,8 @@ ncurses-bin:
 xterm-ghostty-terminfo:
   cmd.run:
   - name: tic -x -o /usr/share/terminfo /usr/local/share/terminfo/xterm-ghostty.src
-  - unless: |
-      src=/usr/local/share/terminfo/xterm-ghostty.src
-      out=/usr/share/terminfo/78/xterm-ghostty
-      alt=/lib/terminfo/78/xterm-ghostty
-      { [ -e "$out" ] && [ "$out" -nt "$src" ]; } || { [ -e "$alt" ] && [ "$alt" -nt "$src" ]; }
   - require:
     - pkg: ncurses-bin
+    - file: /usr/local/share/terminfo/xterm-ghostty.src
+  - onchanges:
     - file: /usr/local/share/terminfo/xterm-ghostty.src

--- a/salt/common/salt.sls
+++ b/salt/common/salt.sls
@@ -21,44 +21,21 @@ salt-minion:
 normalize-srv-infra-perms:
   cmd.run:
     - name: |
-        changed=0
-
-        if find /srv/infra \( ! -user deploy -o ! -group infra \) -print -quit | grep -q .; then
-          changed=1
-        fi
-
-        if find /srv/infra -type d \( ! -perm -2000 -o ! -perm -0770 \) -print -quit | grep -q .; then
-          changed=1
-        fi
-
-        if find /srv/infra -type f ! -perm -0060 -print -quit | grep -q .; then
-          changed=1
-        fi
-
-        if find /srv/infra -type f -perm -u=x ! -perm -g=x -print -quit | grep -q .; then
-          changed=1
-        fi
-
-        if git -C /srv/infra rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-          current="$(git -C /srv/infra config --get core.sharedRepository || true)"
-          if [ "$current" != "group" ]; then
-            changed=1
-          fi
-        fi
-
-        if [ "$changed" -eq 0 ]; then
-          echo "changed=no comment='/srv/infra permissions already normalized'"
-          exit 0
-        fi
-
         chown -R deploy:infra /srv/infra
         chmod -R g+rwX /srv/infra
         find /srv/infra -type d -exec chmod g+s {} +
         if git -C /srv/infra rev-parse --is-inside-work-tree >/dev/null 2>&1; then
           git -C /srv/infra config core.sharedRepository group
         fi
-        echo "changed=yes comment='normalized /srv/infra permissions'"
-    - stateful: True
+    - unless: |
+        find /srv/infra \( ! -user deploy -o ! -group infra \) -print -quit | grep -q . && exit 1
+        find /srv/infra -type d \( ! -perm -2000 -o ! -perm -0770 \) -print -quit | grep -q . && exit 1
+        find /srv/infra -type f ! -perm -0060 -print -quit | grep -q . && exit 1
+        find /srv/infra -type f -perm -u=x ! -perm -g=x -print -quit | grep -q . && exit 1
+        if git -C /srv/infra rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+          [ "$(git -C /srv/infra config --get core.sharedRepository || true)" = "group" ] || exit 1
+        fi
+        exit 0
     - onlyif: test -d /srv/infra
     - require:
       - file: /srv/infra

--- a/salt/common/salt.sls
+++ b/salt/common/salt.sls
@@ -21,12 +21,44 @@ salt-minion:
 normalize-srv-infra-perms:
   cmd.run:
     - name: |
+        changed=0
+
+        if find /srv/infra \( ! -user deploy -o ! -group infra \) -print -quit | grep -q .; then
+          changed=1
+        fi
+
+        if find /srv/infra -type d \( ! -perm -2000 -o ! -perm -0770 \) -print -quit | grep -q .; then
+          changed=1
+        fi
+
+        if find /srv/infra -type f ! -perm -0060 -print -quit | grep -q .; then
+          changed=1
+        fi
+
+        if find /srv/infra -type f -perm -u=x ! -perm -g=x -print -quit | grep -q .; then
+          changed=1
+        fi
+
+        if git -C /srv/infra rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+          current="$(git -C /srv/infra config --get core.sharedRepository || true)"
+          if [ "$current" != "group" ]; then
+            changed=1
+          fi
+        fi
+
+        if [ "$changed" -eq 0 ]; then
+          echo "changed=no comment='/srv/infra permissions already normalized'"
+          exit 0
+        fi
+
         chown -R deploy:infra /srv/infra
         chmod -R g+rwX /srv/infra
         find /srv/infra -type d -exec chmod g+s {} +
         if git -C /srv/infra rev-parse --is-inside-work-tree >/dev/null 2>&1; then
           git -C /srv/infra config core.sharedRepository group
         fi
+        echo "changed=yes comment='normalized /srv/infra permissions'"
+    - stateful: True
     - onlyif: test -d /srv/infra
     - require:
       - file: /srv/infra

--- a/salt/common/salt.sls
+++ b/salt/common/salt.sls
@@ -13,30 +13,22 @@ salt-minion:
     - user: deploy
     - group: infra
     - mode: "2775"
+    - dir_mode: "2775"
+    - file_mode: "0664"
+    - recurse:
+      - user
+      - group
+      - mode
     - require:
       - file: /srv
       - user: deploy
       - group: infra
 
-normalize-srv-infra-perms:
+srv-infra-shared-repository-group:
   cmd.run:
-    - name: |
-        chown -R deploy:infra /srv/infra
-        chmod -R g+rwX /srv/infra
-        find /srv/infra -type d -exec chmod g+s {} +
-        if git -C /srv/infra rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-          git -C /srv/infra config core.sharedRepository group
-        fi
-    - unless: |
-        find /srv/infra \( ! -user deploy -o ! -group infra \) -print -quit | grep -q . && exit 1
-        find /srv/infra -type d \( ! -perm -2000 -o ! -perm -0770 \) -print -quit | grep -q . && exit 1
-        find /srv/infra -type f ! -perm -0060 -print -quit | grep -q . && exit 1
-        find /srv/infra -type f -perm -u=x ! -perm -g=x -print -quit | grep -q . && exit 1
-        if git -C /srv/infra rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-          [ "$(git -C /srv/infra config --get core.sharedRepository || true)" = "group" ] || exit 1
-        fi
-        exit 0
-    - onlyif: test -d /srv/infra
+    - name: git -C /srv/infra config core.sharedRepository group
+    - onlyif: git -C /srv/infra rev-parse --is-inside-work-tree >/dev/null 2>&1
+    - unless: test "$(git -C /srv/infra config --get core.sharedRepository || true)" = "group"
     - require:
       - file: /srv/infra
 

--- a/salt/common/salt.sls
+++ b/salt/common/salt.sls
@@ -27,17 +27,10 @@ normalize-srv-infra-perms:
         if git -C /srv/infra rev-parse --is-inside-work-tree >/dev/null 2>&1; then
           git -C /srv/infra config core.sharedRepository group
         fi
-    - unless: |
-        find /srv/infra \( ! -user deploy -o ! -group infra \) -print -quit | grep -q . && exit 1
-        find /srv/infra -type d \( ! -perm -2000 -o ! -perm -0770 \) -print -quit | grep -q . && exit 1
-        find /srv/infra -type f ! -perm -0060 -print -quit | grep -q . && exit 1
-        find /srv/infra -type f -perm -u=x ! -perm -g=x -print -quit | grep -q . && exit 1
-        if git -C /srv/infra rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-          [ "$(git -C /srv/infra config --get core.sharedRepository || true)" = "group" ] || exit 1
-        fi
-        exit 0
     - onlyif: test -d /srv/infra
     - require:
+      - file: /srv/infra
+    - onchanges:
       - file: /srv/infra
 
 deploy-safe-directory-srv-infra:

--- a/salt/common/salt.sls
+++ b/salt/common/salt.sls
@@ -27,10 +27,17 @@ normalize-srv-infra-perms:
         if git -C /srv/infra rev-parse --is-inside-work-tree >/dev/null 2>&1; then
           git -C /srv/infra config core.sharedRepository group
         fi
+    - unless: |
+        find /srv/infra \( ! -user deploy -o ! -group infra \) -print -quit | grep -q . && exit 1
+        find /srv/infra -type d \( ! -perm -2000 -o ! -perm -0770 \) -print -quit | grep -q . && exit 1
+        find /srv/infra -type f ! -perm -0060 -print -quit | grep -q . && exit 1
+        find /srv/infra -type f -perm -u=x ! -perm -g=x -print -quit | grep -q . && exit 1
+        if git -C /srv/infra rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+          [ "$(git -C /srv/infra config --get core.sharedRepository || true)" = "group" ] || exit 1
+        fi
+        exit 0
     - onlyif: test -d /srv/infra
     - require:
-      - file: /srv/infra
-    - onchanges:
       - file: /srv/infra
 
 deploy-safe-directory-srv-infra:


### PR DESCRIPTION
Avoids repeated "changed" reports on every highstate run for:\n- xterm-ghostty terminfo compilation\n- /srv/infra permissions normalization\n\nChanges:\n- convert both cmd states to \n- run actions only when a pre-check detects drift