### PR TITLE
bertrand: fix invalid nodejs state syntax

### DIFF
--- a/salt/hosts/bertrand/init.sls
+++ b/salt/hosts/bertrand/init.sls
@@ -9,7 +9,7 @@ include:
   - nginx.cloudflare
 
 nodejs:
-  - pkg.installed: []
+  pkg.installed: []
 
 /etc/nginx/certs/namche.ai.cloudflare-origin.crt:
   file.managed:


### PR DESCRIPTION
Fixes failing deploy run due to invalid SLS structure in hosts.bertrand.\n\nError was: .\n\nChange:\n-  state changed from list form to proper dict form ().