### PR TITLE
bertrand: fix paperclip proxy and use NodeSource Node 24

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,12 @@ Changes here affect live system configuration.
 ### Required workflow for changes
 - Prefer idempotent states (safe to run repeatedly).
 - Never introduce interactive commands in states.
+- Always create a feature branch before making changes; never work directly on `main`.
 - Validate syntax before committing:
   - `salt-call --local state.show_sls <state>`
   - `salt-call --local state.apply test=True`
 - Use PR-based merges to `main`; do not push directly to protected branches.
+- Push the feature branch to GitHub as soon as it contains reviewable work so the user can review progress while you continue.
 - Deploy from the host checkout (`/srv/infra`) as `deploy` with non-interactive sudo:
   - `ssh deploy@bertrand.batlogg.com 'cd /srv/infra && git pull && sudo -n /usr/bin/salt-call --local state.apply terse=true'`
 - After deployment, report the Salt summary (`Succeeded`/`Failed`) and key changed states.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ Changes here affect live system configuration.
   - `salt-call --local state.apply test=True`
 - Use PR-based merges to `main`; do not push directly to protected branches.
 - Push the feature branch to GitHub as soon as it contains reviewable work so the user can review progress while you continue.
+- After pushing a review branch, always show the user the clickable PR URL in your reply.
 - Deploy from the host checkout (`/srv/infra`) as `deploy` with non-interactive sudo:
   - `ssh deploy@bertrand.batlogg.com 'cd /srv/infra && git pull && sudo -n /usr/bin/salt-call --local state.apply terse=true'`
 - After deployment, report the Salt summary (`Succeeded`/`Failed`) and key changed states.

--- a/salt/hosts/bertrand/init.sls
+++ b/salt/hosts/bertrand/init.sls
@@ -4,15 +4,10 @@ include:
   - hosts.bertrand.volumes
   - docker
   - tailscale
+  - nodejs
   - openclaw
   - nginx
   - nginx.cloudflare
-
-nodejs:
-  pkg.installed: []
-
-npm:
-  pkg.installed: []
 
 /etc/nginx/certs/namche.ai.cloudflare-origin.crt:
   file.managed:

--- a/salt/hosts/bertrand/namche.ai.conf
+++ b/salt/hosts/bertrand/namche.ai.conf
@@ -47,11 +47,10 @@ server {
     include conf.d/ssl.conf.inc;
 
     location / {
+        proxy_http_version 1.1;
         include /etc/nginx/proxy_params;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
         proxy_pass http://127.0.0.1:3100;
     }
 


### PR DESCRIPTION
## Summary
- fix `paperclip.namche.ai` nginx proxy settings for websocket-capable upstream handling
- switch `bertrand` from distro `nodejs`/`npm` packages to the reusable NodeSource-backed Node 24 Salt state
- document infra workflow expectations to branch first, push early, and always share the PR URL

## Notes
- changes are limited to `bertrand` host wiring and repo instructions
- Salt validation has not been run yet