### PR TITLE
feat: add reusable supabase Salt module

### DIFF
--- a/salt/hosts/bertrand/init.sls
+++ b/salt/hosts/bertrand/init.sls
@@ -5,6 +5,7 @@ include:
   - docker
   - tailscale
   - nodejs
+  - supabase
   - openclaw
   - nginx
   - nginx.cloudflare

--- a/salt/supabase/init.sls
+++ b/salt/supabase/init.sls
@@ -1,16 +1,13 @@
 include:
   - docker
-  - nodejs
+
+git:
+  pkg.installed: []
 
 /srv/supabase:
   file.directory:
     - user: root
     - group: root
     - mode: "0755"
-
-supabase-cli:
-  cmd.run:
-    - name: npm install -g supabase
-    - unless: command -v supabase >/dev/null 2>&1
     - require:
-      - file: /srv/supabase
+      - pkg: git

--- a/salt/supabase/init.sls
+++ b/salt/supabase/init.sls
@@ -1,13 +1,5 @@
-include:
-  - docker
-
-git:
-  pkg.installed: []
-
 /srv/supabase:
   file.directory:
     - user: root
     - group: root
     - mode: "0755"
-    - require:
-      - pkg: git

--- a/salt/supabase/init.sls
+++ b/salt/supabase/init.sls
@@ -1,0 +1,16 @@
+include:
+  - docker
+  - nodejs
+
+/srv/supabase:
+  file.directory:
+    - user: root
+    - group: root
+    - mode: "0755"
+
+supabase-cli:
+  cmd.run:
+    - name: npm install -g supabase
+    - unless: command -v supabase >/dev/null 2>&1
+    - require:
+      - file: /srv/supabase


### PR DESCRIPTION
## Summary
- add a generic `supabase` Salt module
- install the Supabase CLI via npm with reusable module wiring
- include `supabase` on `bertrand`

## Notes
- this is only the generic module and host include
- the Supabase instance/project setup will follow separately