### PR TITLE
apps.searxng: add compose deployment on bertrand

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ Changes here affect live system configuration.
 - Keep includes explicit: host init states should compose reusable modules plus host-local files.
 - Minimize Jinja; prefer clear declarative states unless templating is truly needed.
 - Keep states idempotent and deterministic.
+- Do not use `service.running` in Salt states in this repo; prefer `service.enabled` plus explicit `cmd.run` restarts/reloads on file changes.
 
 ### Boundaries and ownership
 - Host-specific data must not leak into generic modules.

--- a/salt/apps/searxng/.env
+++ b/salt/apps/searxng/.env
@@ -1,0 +1,15 @@
+# Read the documentation before using the `docker-compose.yml` file:
+# https://docs.searxng.org/admin/installation-docker.html
+#
+# Additional ENVs:
+# https://docs.searxng.org/admin/settings/settings_general.html#settings-general
+# https://docs.searxng.org/admin/settings/settings_server.html#settings-server
+
+# Use a specific version tag. E.g. "latest" or "2026.3.25-541c6c3cb".
+#SEARXNG_VERSION=latest
+
+# Listen to a specific address.
+SEARXNG_HOST=127.0.0.1
+
+# Listen to a specific port.
+SEARXNG_PORT=8080

--- a/salt/apps/searxng/.env
+++ b/salt/apps/searxng/.env
@@ -8,8 +8,5 @@
 # Use a specific version tag. E.g. "latest" or "2026.3.25-541c6c3cb".
 #SEARXNG_VERSION=latest
 
-# Listen to a specific address.
-SEARXNG_HOST=127.0.0.1
-
 # Listen to a specific port.
 SEARXNG_PORT=8080

--- a/salt/apps/searxng/docker-compose.yml
+++ b/salt/apps/searxng/docker-compose.yml
@@ -1,0 +1,28 @@
+# Read the documentation before using the `docker-compose.yml` file:
+# https://docs.searxng.org/admin/installation-docker.html
+
+name: searxng
+
+services:
+  core:
+    container_name: searxng-core
+    image: docker.io/searxng/searxng:${SEARXNG_VERSION:-latest}
+    restart: always
+    ports:
+      - ${SEARXNG_HOST:+${SEARXNG_HOST}:}${SEARXNG_PORT:-8080}:${SEARXNG_PORT:-8080}
+    env_file: ./.env
+    volumes:
+      - ./core-config/:/etc/searxng/:Z
+      - core-data:/var/cache/searxng/
+
+  valkey:
+    container_name: searxng-valkey
+    image: docker.io/valkey/valkey:9-alpine
+    command: valkey-server --save 30 1 --loglevel warning
+    restart: always
+    volumes:
+      - valkey-data:/data/
+
+volumes:
+  core-data:
+  valkey-data:

--- a/salt/apps/searxng/init.sls
+++ b/salt/apps/searxng/init.sls
@@ -1,4 +1,4 @@
-/home/deploy/apps:
+/home/deploy/apps/searxng:
   file.directory:
     - user: deploy
     - group: deploy
@@ -7,18 +7,8 @@
     - require:
       - user: deploy
 
-/home/deploy/apps/searxng:
-  file.directory:
-    - user: deploy
-    - group: deploy
-    - mode: "0755"
-    - require:
-      - file: /home/deploy/apps
-
 /home/deploy/apps/searxng/core-config:
   file.directory:
-    - user: deploy
-    - group: deploy
     - mode: "0755"
     - require:
       - file: /home/deploy/apps/searxng
@@ -54,22 +44,23 @@ searxng-systemd-daemon-reload:
     - onchanges:
       - file: /etc/systemd/system/searxng.service
 
-searxng-service-running:
-  service.running:
+searxng-service-enabled:
+  service.enabled:
     - name: searxng
-    - enable: True
     - require:
-      - pkg: docker
       - file: /home/deploy/apps/searxng/docker-compose.yml
       - file: /home/deploy/apps/searxng/.env
       - file: /etc/systemd/system/searxng.service
       - cmd: searxng-systemd-daemon-reload
 
-searxng-service-reload:
+searxng-service-restart:
   cmd.run:
-    - name: systemctl reload searxng
+    - name: systemctl restart searxng.service
     - onchanges:
       - file: /home/deploy/apps/searxng/docker-compose.yml
       - file: /home/deploy/apps/searxng/.env
+      - file: /etc/systemd/system/searxng.service
     - require:
-      - service: searxng-service-running
+      - pkg: docker
+      - service: searxng-service-enabled
+      - cmd: searxng-systemd-daemon-reload

--- a/salt/apps/searxng/init.sls
+++ b/salt/apps/searxng/init.sls
@@ -1,0 +1,75 @@
+/home/deploy/apps:
+  file.directory:
+    - user: deploy
+    - group: deploy
+    - mode: "0755"
+    - makedirs: True
+    - require:
+      - user: deploy
+
+/home/deploy/apps/searxng:
+  file.directory:
+    - user: deploy
+    - group: deploy
+    - mode: "0755"
+    - require:
+      - file: /home/deploy/apps
+
+/home/deploy/apps/searxng/core-config:
+  file.directory:
+    - user: deploy
+    - group: deploy
+    - mode: "0755"
+    - require:
+      - file: /home/deploy/apps/searxng
+
+/home/deploy/apps/searxng/docker-compose.yml:
+  file.managed:
+    - source: salt://apps/searxng/docker-compose.yml
+    - user: deploy
+    - group: deploy
+    - mode: "0644"
+    - require:
+      - file: /home/deploy/apps/searxng
+
+/home/deploy/apps/searxng/.env:
+  file.managed:
+    - source: salt://apps/searxng/.env
+    - user: deploy
+    - group: deploy
+    - mode: "0644"
+    - require:
+      - file: /home/deploy/apps/searxng
+
+/etc/systemd/system/searxng.service:
+  file.managed:
+    - source: salt://apps/searxng/searxng.service
+    - user: root
+    - group: root
+    - mode: "0644"
+
+searxng-systemd-daemon-reload:
+  cmd.run:
+    - name: systemctl daemon-reload
+    - onchanges:
+      - file: /etc/systemd/system/searxng.service
+
+searxng-service-running:
+  service.running:
+    - name: searxng
+    - enable: True
+    - require:
+      - pkg: docker
+      - file: /home/deploy/apps/searxng/docker-compose.yml
+      - file: /home/deploy/apps/searxng/.env
+      - file: /etc/systemd/system/searxng.service
+      - cmd: searxng-systemd-daemon-reload
+
+searxng-service-reload:
+  cmd.run:
+    - name: systemctl reload searxng
+    - onchanges:
+      - file: /home/deploy/apps/searxng/docker-compose.yml
+      - file: /home/deploy/apps/searxng/.env
+    - require:
+      - service: searxng-service-running

--- a/salt/apps/searxng/searxng.service
+++ b/salt/apps/searxng/searxng.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=SearXNG (Docker Compose)
+After=network-online.target docker.service
+Wants=network-online.target
+Requires=docker.service
+
+[Service]
+Type=oneshot
+User=deploy
+Group=deploy
+WorkingDirectory=/home/deploy/apps/searxng
+RemainAfterExit=yes
+ExecStart=/usr/bin/docker compose up -d
+ExecStop=/usr/bin/docker compose down
+ExecReload=/usr/bin/docker compose up -d
+TimeoutStartSec=0
+
+[Install]
+WantedBy=multi-user.target

--- a/salt/docker/init.sls
+++ b/salt/docker/init.sls
@@ -36,5 +36,6 @@ docker:
   group.present:
     - addusers:
       - admin
+      - deploy
 
   {%- endif %}

--- a/salt/hosts/bertrand/init.sls
+++ b/salt/hosts/bertrand/init.sls
@@ -1,5 +1,6 @@
 include:
   - apps.api-proxy
+  - apps.searxng
   - hosts.bertrand.deploy
   - hosts.bertrand.volumes
   - docker


### PR DESCRIPTION
## Summary
- add a new `apps.searxng` Salt state for a Docker Compose deployment under `/home/deploy/apps/searxng`
- add a systemd unit so the SearXNG compose stack is started automatically
- grant `deploy` access to Docker so the systemd unit can run `docker compose`
- include the app state on `bertrand`

## Testing
- `git diff --check`
- `salt-call --local state.show_sls apps.searxng` not run here (`salt-call` is not installed in this environment)
- `salt-call --local state.apply apps.searxng test=True` not run here (`salt-call` is not installed in this environment)

## Notes
- SearXNG currently binds to `127.0.0.1:8080`
- nginx/TLS wiring for `searxng.khumbu.namche.ai` is intentionally left for a follow-up change