### PR TITLE
apps.searxng: restart after docker group changes

### DIFF
--- a/salt/apps/searxng/init.sls
+++ b/salt/apps/searxng/init.sls
@@ -57,10 +57,12 @@ searxng-service-restart:
   cmd.run:
     - name: systemctl restart searxng.service
     - onchanges:
+      - group: docker
       - file: /home/deploy/apps/searxng/docker-compose.yml
       - file: /home/deploy/apps/searxng/.env
       - file: /etc/systemd/system/searxng.service
     - require:
       - pkg: docker
+      - group: docker
       - service: searxng-service-enabled
       - cmd: searxng-systemd-daemon-reload


### PR DESCRIPTION
## Summary
- restart `searxng.service` when the `docker` group membership changes
- make the SearXNG Salt state react to the `deploy` user being added to the docker group

## Testing
- `git diff --check`
- `salt-call --local state.show_sls apps.searxng` not run here (`salt-call` is not installed in this environment)
- `salt-call --local state.apply apps.searxng test=True` not run here (`salt-call` is not installed in this environment)

## Context
- the initial deployment failed because `deploy` gained docker access in the same run, but the service restart only watched file changes