### PR TITLE
bertrand: add internal khumbu edge

### DIFF
--- a/pillar/hosts/bertrand.sls
+++ b/pillar/hosts/bertrand.sls
@@ -1,1 +1,8 @@
-# Host-specific secrets remain in encrypted pillar (`pillar/secrets.sls`).
+letsencrypt:
+  mode: dns-cloudflare
+  dns_cloudflare_credentials_pillar: secrets:vault:cloudflare:dns_api_tokens:namche.ai
+  certs:
+    khumbu.namche.ai:
+    - '*.khumbu.namche.ai'
+  deploy_hooks:
+  - /bin/systemctl try-restart nginx.service

--- a/pillar/secrets.sls
+++ b/pillar/secrets.sls
@@ -2,9 +2,11 @@
 # format to the ``vault`` section of the file.
 # This is along https://docs.saltstack.com/en/latest/topics/pillar/index.html#pillar-encryption
 
-# to encrypt the text ``bar`` use this commandline (of course you have to replace
-# the e-mail adress as well):
-# echo -n bar | gpg --armor --trust-model always --encrypt -r user@domain.tld | sed ':a;N;$!ba;s/\n/\\n/g'
+# To encrypt the text ``bar`` use this command line (of course you have to
+# replace the e-mail address as well):
+# echo -n bar | gpg --armor --trust-model always --encrypt -r user@domain.tld
+# Then paste the armored output below as a YAML block scalar (`|`).
+# If your GPG frontend adds a `Comment:` header, omit that line when pasting.
 
 secrets:
   vault:
@@ -112,4 +114,25 @@ secrets:
           28MUwVIvMS2o6plWQILpBBZ3N3PCPU6ah+xoMQzAZHuAa/wRSQvmjr8ORs6wDKhp
           DbgFUPvaM0lN
           =9Njs
-          -----END PGP MESSAGE-----        
+          -----END PGP MESSAGE-----
+    cloudflare:
+      dns_api_tokens:
+        namche.ai: |
+          -----BEGIN PGP MESSAGE-----
+
+          hQIMA5ZHxiCsLfFyARAAmMnu6e41GQj7fmAnmolaeEKMkXwDcKQInolsLv8Ode/T
+          xieg8g/MjBjQcl35+eQJqYEWPlQfd3+0ydaB6SYMxj/A9LOgGP1LyTYrtL2zSz/z
+          CjAbeMkhxjGt8t4wrMTSRO2PoIuIAWAwCGnlVSSMGysKkJwB0Q4iFmD7Xbptw4b+
+          sp5XYZRLrfgaZG4YOYUeNg6XH/ozVEax0amwDZPyzJUdxmCViJ69wrrE/mhST+2A
+          4z9h4MHk1Mo4mkKkpI1YHszikUgwO/9O6VfRts+LEpBaLohJ+sdLv24oRwvzpSsP
+          rPwE0Zx5oXdzkntFSLEJcKWXt+k8EG/y2XISlJrklf9WTk9YKDDbaFZ0uorWHioc
+          eZEAEzJ9tF4DIU+9eFWuFik4WTvM0axWyOiJg0IhfwXljZQkhc3P6ZmUiB6jfA+k
+          wIzSNq7QmuJO13I+T+ZinEbf8BGoya2LFvwJY9yjjjsFXjqjYEq8Z9WWF473PML4
+          5Dqnf2QduA9Agm/pdnnuZcKaJ+/Mi1X0PqnfbiP5C44rYQjFpeBX57lcuqGhlpHb
+          eKQD24W0cBda5s2/nsYb4zbMHyMae3t2XiNllIft7Ghoi7TP5+gcsTbYk7p27nBO
+          B7WqgD4TtQ4ZOBl/nZ6DEh1Bz/MAaNNXBCXMO//AIoozuZfCVKL4yzyuASQeSCbU
+          egEJAhDM0izrW7DAjtgciJm8aXPTJ4zTJWpFPJsSD+Xj453jbF1RELv6RIHO37yR
+          xthiVdCLoGYdNPCf+HOnnG18xtkNk3r2OKngjPS6uPQJNv4+lxt0CWAUTfNYcRRq
+          0iubaat9dbgVj2xLS/LAjAk8+0o/1sZb+nhA
+          =mbN4
+          -----END PGP MESSAGE-----

--- a/salt/hosts/bertrand/init.sls
+++ b/salt/hosts/bertrand/init.sls
@@ -4,6 +4,7 @@ include:
   - hosts.bertrand.deploy
   - hosts.bertrand.volumes
   - docker
+  - letsencrypt
   - tailscale
   - nodejs
   - openclaw
@@ -33,6 +34,12 @@ include:
   file.managed:
   - source: salt://hosts/bertrand/namche.ai.conf
 
+/etc/nginx/conf.d/khumbu.namche.ai.conf:
+  file.managed:
+  - source: salt://hosts/bertrand/khumbu.namche.ai.conf
+  - require:
+    - cmd: /etc/letsencrypt/live/khumbu.namche.ai/fullchain.pem
+
 nginx-reload:
   cmd.run:
   - name: systemctl try-restart nginx.service
@@ -40,3 +47,4 @@ nginx-reload:
     - file: /etc/nginx/certs/namche.ai.cloudflare-origin.crt
     - file: /etc/nginx/certs/namche.ai.cloudflare-origin.key
     - file: /etc/nginx/conf.d/namche.ai.conf  
+    - file: /etc/nginx/conf.d/khumbu.namche.ai.conf

--- a/salt/hosts/bertrand/khumbu.namche.ai.conf
+++ b/salt/hosts/bertrand/khumbu.namche.ai.conf
@@ -1,0 +1,29 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name searxng.khumbu.namche.ai;
+
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name searxng.khumbu.namche.ai;
+
+    ssl_certificate /etc/letsencrypt/live/khumbu.namche.ai/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/khumbu.namche.ai/privkey.pem;
+    ssl_trusted_certificate /etc/letsencrypt/live/khumbu.namche.ai/chain.pem;
+    include conf.d/ssl.conf.inc;
+
+    location / {
+        proxy_http_version 1.1;
+        include /etc/nginx/proxy_params;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_pass http://127.0.0.1:8080;
+    }
+
+    access_log /var/log/nginx/searxng.khumbu.namche.ai.access.log;
+    error_log /var/log/nginx/searxng.khumbu.namche.ai.error.log;
+}

--- a/salt/letsencrypt/init.sls
+++ b/salt/letsencrypt/init.sls
@@ -1,5 +1,13 @@
+{%- set letsencrypt_mode_name = pillar['letsencrypt']['mode'] %}
+{%- if letsencrypt_mode_name == 'dns-cloudflare' %}
+  {%- set certbot_packages = ['certbot', 'python3-certbot-dns-cloudflare'] %}
+{%- else %}
+  {%- set certbot_packages = ['certbot'] %}
+{%- endif %}
+
 certbot:
-  pkg.installed: []
+  pkg.installed:
+    - pkgs: {{ certbot_packages }}
 
 {%- if grains['os_family'] == 'RedHat' %}
   {%- set certbot_config_path = '/etc/sysconfig/certbot' %}
@@ -29,10 +37,22 @@ letsencrypt:
   - user: root
   - group: letsencrypt
   
-{%- if pillar['letsencrypt']['mode'] == 'standalone' %}
+{%- if letsencrypt_mode_name == 'standalone' %}
   {%- set letsencrypt_mode = '--standalone' %}
+{%- elif letsencrypt_mode_name == 'dns-cloudflare' %}
+  {%- set letsencrypt_mode = '--dns-cloudflare --dns-cloudflare-credentials /etc/letsencrypt/cloudflare.ini' %}
 {%- else %}
   {%- set letsencrypt_mode = '--webroot -w /var/lib/letsencrypt/' %}
+{%- endif %}
+
+{%- if letsencrypt_mode_name == 'dns-cloudflare' %}
+/etc/letsencrypt/cloudflare.ini:
+  file.managed:
+  - user: root
+  - group: root
+  - mode: "0600"
+  - contents_pillar: {{ pillar['letsencrypt']['dns_cloudflare_credentials_pillar'] }}
+  - show_changes: false
 {%- endif %}
 
 {%- for cert, domains in salt['pillar.get']('letsencrypt:certs', {}).items() %}
@@ -40,6 +60,10 @@ letsencrypt:
   cmd.run:
   - name: /bin/certbot certonly -n --agree-tos --expand -m jodok@batlogg.com {{ letsencrypt_mode }} -d {{ cert }}{%- for domain in domains %} -d {{ domain }}{%- endfor %}
   - unless: test -e /etc/letsencrypt/live/{{ cert }}/fullchain.pem
+  {%- if letsencrypt_mode_name == 'dns-cloudflare' %}
+  - require:
+    - file: /etc/letsencrypt/cloudflare.ini
+  {%- endif %}
 
 /etc/letsencrypt/archive/{{ cert }}:
   file.directory:


### PR DESCRIPTION
## Summary
- add DNS-01 support for Cloudflare to the existing Let's Encrypt Salt module
- configure `bertrand` to request `khumbu.namche.ai` and `*.khumbu.namche.ai`
- add an internal nginx vhost for `searxng.khumbu.namche.ai`
- store the Cloudflare DNS API token in encrypted pillar and document the block-scalar secret workflow

## Testing
- `git diff --check`
- `salt-call --local state.show_sls letsencrypt` not run here (`salt-call` is not installed in this environment)
- `salt-call --local state.show_sls hosts.bertrand` not run here (`salt-call` is not installed in this environment)
- `salt-call --local state.apply test=True` not run here (`salt-call` is not installed in this environment)

## Notes
- the nginx vhost is gated on the certificate existing, to avoid breaking nginx before the first successful DNS-01 issuance
- Split DNS for `khumbu.namche.ai` still needs to be configured outside this repo