### PR TITLE
Fix duplicated zsh host segment

### DIFF
--- a/salt/common/bash.sls
+++ b/salt/common/bash.sls
@@ -12,8 +12,8 @@
         prompt_command() {
           local exit="$?"
 
-          # hostname (red)
-          local host="\[\033[31m\]\h\[\033[0m\] "
+          # user@host (yellow user, red host)
+          local identity="\[\033[33m\]\u@\[\033[31m\]\h\[\033[0m\] "
 
           # arrow (green/red based on exit)
           if [ "$exit" -eq 0 ]; then
@@ -32,43 +32,10 @@
             git_branch="git:($git_branch) "
           fi
 
-          PS1="${host}${arrow}${cwd}${git_branch}"
+          PS1="${identity}${arrow}${cwd}${git_branch}"
         }
 
         PROMPT_COMMAND=prompt_command
-
-/etc/zsh/zshrc-prompt:
-  file.blockreplace:
-    - name: /etc/zsh/zshrc
-    - marker_start: "# START managed by salt: common.zsh prompt"
-    - marker_end: "# END managed by salt: common.zsh prompt"
-    - append_if_not_found: True
-    - content: |
-        parse_git_branch() {
-          git branch --show-current 2>/dev/null
-        }
-
-        setopt prompt_subst
-
-        precmd() {
-          local exit_status="$?"
-          local arrow
-          local git_branch
-
-          if [ "$exit_status" -eq 0 ]; then
-            arrow="%B%F{green}➜%f%b"
-          else
-            arrow="%B%F{red}➜%f%b"
-          fi
-
-          git_branch="$(parse_git_branch)"
-          if [ -n "$git_branch" ]; then
-            git_branch=" git:(${git_branch})"
-          fi
-
-          PROMPT="%F{yellow}%n@%m%f ${arrow}  %F{cyan}%1~%f${git_branch} "
-          RPROMPT=""
-        }
 
 # Ghostty
 ncurses-bin:

--- a/salt/common/bash.sls
+++ b/salt/common/bash.sls
@@ -37,6 +37,39 @@
 
         PROMPT_COMMAND=prompt_command
 
+/etc/zsh/zshrc-prompt:
+  file.blockreplace:
+    - name: /etc/zsh/zshrc
+    - marker_start: "# START managed by salt: common.zsh prompt"
+    - marker_end: "# END managed by salt: common.zsh prompt"
+    - append_if_not_found: True
+    - content: |
+        parse_git_branch() {
+          git branch --show-current 2>/dev/null
+        }
+
+        setopt prompt_subst
+
+        precmd() {
+          local exit_status="$?"
+          local arrow
+          local git_branch
+
+          if [ "$exit_status" -eq 0 ]; then
+            arrow="%B%F{green}➜%f%b"
+          else
+            arrow="%B%F{red}➜%f%b"
+          fi
+
+          git_branch="$(parse_git_branch)"
+          if [ -n "$git_branch" ]; then
+            git_branch=" git:(${git_branch})"
+          fi
+
+          PROMPT="%F{yellow}%n@%m%f ${arrow}  %F{cyan}%1~%f${git_branch} "
+          RPROMPT=""
+        }
+
 # Ghostty
 ncurses-bin:
   pkg.installed: []


### PR DESCRIPTION
## Summary
- manage a global zsh prompt via Salt
- set the prompt explicitly to user@host to avoid zsh theme fallback duplication on hosts like nima
- keep the existing arrow/cwd/git-branch behavior aligned with the shared shell prompt

## Validation
- zsh syntax check on the embedded prompt snippet
- salt-call validation could not be run locally because salt-call is not installed in this workspace