### PR TITLE
bertrand: add openclaw claude bridge

### DIFF
--- a/pillar/hosts/bertrand.sls
+++ b/pillar/hosts/bertrand.sls
@@ -6,10 +6,3 @@ letsencrypt:
     - '*.khumbu.namche.ai'
   deploy_hooks:
   - /bin/systemctl try-restart nginx.service
-
-openclaw:
-  claude_bridge:
-    repo: https://github.com/shinglokto/openclaw-claude-bridge.git
-    rev: c828f45bfc7a8690487a1b06d0dec591b9857fcf
-    api_port: 3456
-    status_port: 3458

--- a/pillar/hosts/bertrand.sls
+++ b/pillar/hosts/bertrand.sls
@@ -6,3 +6,10 @@ letsencrypt:
     - '*.khumbu.namche.ai'
   deploy_hooks:
   - /bin/systemctl try-restart nginx.service
+
+openclaw:
+  claude_bridge:
+    repo: https://github.com/shinglokto/openclaw-claude-bridge.git
+    rev: c828f45bfc7a8690487a1b06d0dec591b9857fcf
+    api_port: 3456
+    status_port: 3458

--- a/pillar/secrets.sls
+++ b/pillar/secrets.sls
@@ -136,3 +136,25 @@ secrets:
           0iubaat9dbgVj2xLS/LAjAk8+0o/1sZb+nhA
           =mbN4
           -----END PGP MESSAGE-----
+    openclaw:
+      claude_bridge:
+        dashboard_pass: |
+          -----BEGIN PGP MESSAGE-----
+          Comment: GPGTools - http://gpgtools.org
+
+          hQIMA0QvKRCOLt9nARAAyI9oncUFEmdF9qaQ7OXZBwLyeBVqHiuROwAgpV08cm2u
+          Jfachhw9/eSX4g/mwFbdu6/ln/bhfDKBvmZgAXgJQk9QJCQ7tD6YqTSkBjdnRo+8
+          ohUsRpvJ2DPGXc9+S4JHQFDJSeQUXePujRdWmYC1xmO5LqmMKhMQtto8fTB4Ng46
+          ta6A7D91WGCxMMI6DROC0xqlzmXiSLPweCbtVp1HGJnK7neVc1+xW3SXIQztyimR
+          tf4cdVb0gjrWA0x3jfuKkxg1++jxYcyBGOUSwsV/Gyh/iKuXxXo2I3nVG6z3KNvj
+          VwHdktlKW6f5aW/epXo9Holk3ZdBLVqZ/TJFMpZhVPfq/TcsgRnBtW6W98LRbk4X
+          k1okA0/NJ7S7gsx928rhxoGqPDaiSFgR4nbC48KaonuguYP0TfZa+bYDchj4+3Z8
+          B0mm8SFJpTXPSKzlF+w5CD0U9PIOKEhg3EsQEAsGlfKqXQXQFpxxPDoMjOxJ76BW
+          qE9FYTTzWHIAZP/aMlpSwo2PqYv05l5zf/B74ztKGDacAALmjbp/KCj3B0NMr4Et
+          20x8lI/uNDVB8jH54nQputDcOOw+ldU0JSVh8/mCBc2Z7WBxxq2y3rIW61ZV9Xmy
+          Bg9vWD0qZsAog+pRpo4um12t/6qgD1KbSCuBV6qKTnJHVNad/blfF+Gejdy5xFzS
+          dgE/iiLQqI9A4HPa+Mblg5n6HTNUHRLmi9B2N7IgHTOLF0nqCTCnmpfQbX6Kq0OS
+          wzze+zTNMol72E4kb0E/JfmDGNWQy32JMKPR4hnfS5n1u9Dul4lGZ3L5Z31MrUcn
+          dLXNasD2DKqFxwv6kBTm5XR9kYREHRg=
+          =MuNT
+          -----END PGP MESSAGE-----

--- a/salt/hosts/bertrand/claude-bridge.khumbu.namche.ai.conf
+++ b/salt/hosts/bertrand/claude-bridge.khumbu.namche.ai.conf
@@ -15,22 +15,18 @@ server {
     ssl_certificate_key /etc/letsencrypt/live/khumbu.namche.ai/privkey.pem;
     ssl_trusted_certificate /etc/letsencrypt/live/khumbu.namche.ai/chain.pem;
     include conf.d/ssl.conf.inc;
+    proxy_http_version 1.1;
+    include /etc/nginx/proxy_params;
 
     location /v1/ {
-        proxy_http_version 1.1;
-        include /etc/nginx/proxy_params;
         proxy_pass http://127.0.0.1:3456;
     }
 
     location = /health {
-        proxy_http_version 1.1;
-        include /etc/nginx/proxy_params;
         proxy_pass http://127.0.0.1:3456;
     }
 
     location / {
-        proxy_http_version 1.1;
-        include /etc/nginx/proxy_params;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_pass http://127.0.0.1:3458;

--- a/salt/hosts/bertrand/claude-bridge.khumbu.namche.ai.conf
+++ b/salt/hosts/bertrand/claude-bridge.khumbu.namche.ai.conf
@@ -1,0 +1,41 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name claude-bridge.khumbu.namche.ai;
+
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name claude-bridge.khumbu.namche.ai;
+
+    ssl_certificate /etc/letsencrypt/live/khumbu.namche.ai/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/khumbu.namche.ai/privkey.pem;
+    ssl_trusted_certificate /etc/letsencrypt/live/khumbu.namche.ai/chain.pem;
+    include conf.d/ssl.conf.inc;
+
+    location /v1/ {
+        proxy_http_version 1.1;
+        include /etc/nginx/proxy_params;
+        proxy_pass http://127.0.0.1:3456;
+    }
+
+    location = /health {
+        proxy_http_version 1.1;
+        include /etc/nginx/proxy_params;
+        proxy_pass http://127.0.0.1:3456;
+    }
+
+    location / {
+        proxy_http_version 1.1;
+        include /etc/nginx/proxy_params;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_pass http://127.0.0.1:3458;
+    }
+
+    access_log /var/log/nginx/claude-bridge.khumbu.namche.ai.access.log;
+    error_log /var/log/nginx/claude-bridge.khumbu.namche.ai.error.log;
+}

--- a/salt/hosts/bertrand/init.sls
+++ b/salt/hosts/bertrand/init.sls
@@ -40,6 +40,12 @@ include:
   - require:
     - cmd: /etc/letsencrypt/live/khumbu.namche.ai/fullchain.pem
 
+/etc/nginx/conf.d/claude-bridge.khumbu.namche.ai.conf:
+  file.managed:
+  - source: salt://hosts/bertrand/claude-bridge.khumbu.namche.ai.conf
+  - require:
+    - cmd: /etc/letsencrypt/live/khumbu.namche.ai/fullchain.pem
+
 nginx-reload:
   cmd.run:
   - name: systemctl try-restart nginx.service
@@ -48,3 +54,4 @@ nginx-reload:
     - file: /etc/nginx/certs/namche.ai.cloudflare-origin.key
     - file: /etc/nginx/conf.d/namche.ai.conf  
     - file: /etc/nginx/conf.d/khumbu.namche.ai.conf
+    - file: /etc/nginx/conf.d/claude-bridge.khumbu.namche.ai.conf

--- a/salt/openclaw/bridge.env.j2
+++ b/salt/openclaw/bridge.env.j2
@@ -1,7 +1,1 @@
-OPENCLAW_BRIDGE_PORT={{ salt['pillar.get']('openclaw:claude_bridge:api_port', 3456) }}
-OPENCLAW_BRIDGE_STATUS_PORT={{ salt['pillar.get']('openclaw:claude_bridge:status_port', 3458) }}
 DASHBOARD_PASS={{ salt['pillar.get']('secrets:vault:openclaw:claude_bridge:dashboard_pass') }}
-{% set claude_bin = salt['pillar.get']('openclaw:claude_bridge:claude_bin', '') %}
-{% if claude_bin %}
-CLAUDE_BIN={{ claude_bin }}
-{% endif %}

--- a/salt/openclaw/bridge.env.j2
+++ b/salt/openclaw/bridge.env.j2
@@ -1,1 +1,17 @@
+# Optional: Claude CLI model aliases
+# OPUS_MODEL=opus
+# SONNET_MODEL=sonnet
+# HAIKU_MODEL=haiku
+#
+# Optional: idle timeout in milliseconds
+# IDLE_TIMEOUT_MS=120000
+#
+# Optional: bridge ports
+# OPENCLAW_BRIDGE_PORT=3456
+# OPENCLAW_BRIDGE_STATUS_PORT=3458
+#
+# Optional: path to the Claude CLI binary
+# CLAUDE_BIN=/home/deploy/.local/bin/claude
+#
+# Dashboard basic auth password (user: admin)
 DASHBOARD_PASS={{ salt['pillar.get']('secrets:vault:openclaw:claude_bridge:dashboard_pass') }}

--- a/salt/openclaw/bridge.env.j2
+++ b/salt/openclaw/bridge.env.j2
@@ -1,0 +1,7 @@
+OPENCLAW_BRIDGE_PORT={{ salt['pillar.get']('openclaw:claude_bridge:api_port', 3456) }}
+OPENCLAW_BRIDGE_STATUS_PORT={{ salt['pillar.get']('openclaw:claude_bridge:status_port', 3458) }}
+DASHBOARD_PASS={{ salt['pillar.get']('secrets:vault:openclaw:claude_bridge:dashboard_pass') }}
+{% set claude_bin = salt['pillar.get']('openclaw:claude_bridge:claude_bin', '') %}
+{% if claude_bin %}
+CLAUDE_BIN={{ claude_bin }}
+{% endif %}

--- a/salt/openclaw/init.sls
+++ b/salt/openclaw/init.sls
@@ -9,7 +9,7 @@
 
 openclaw-claude-bridge-repo:
   cmd.run:
-    - name: git clone https://github.com/shinglokto/openclaw-claude-bridge.git /home/deploy/apps/openclaw-claude-bridge && git -C /home/deploy/apps/openclaw-claude-bridge checkout c828f45bfc7a8690487a1b06d0dec591b9857fcf
+    - name: git clone https://github.com/shinglokto/openclaw-claude-bridge.git /home/deploy/apps/openclaw-claude-bridge
     - runas: deploy
     - creates: /home/deploy/apps/openclaw-claude-bridge/.git
     - require:
@@ -24,7 +24,7 @@ openclaw-claude-bridge-repo:
     - mode: "0600"
     - show_changes: false
     - require:
-      - git: openclaw-claude-bridge-repo
+      - cmd: openclaw-claude-bridge-repo
 
 openclaw-claude-bridge-install:
   cmd.run:
@@ -37,7 +37,7 @@ openclaw-claude-bridge-install:
         PATH: /home/deploy/.local/bin:/usr/local/bin:/usr/bin:/bin
     - require:
       - pkg: nodejs
-      - git: openclaw-claude-bridge-repo
+      - cmd: openclaw-claude-bridge-repo
 
 /etc/systemd/system/openclaw-claude-bridge.service:
   file.managed:

--- a/salt/openclaw/init.sls
+++ b/salt/openclaw/init.sls
@@ -8,13 +8,10 @@
       - user: deploy
 
 openclaw-claude-bridge-repo:
-  git.latest:
-    - name: {{ salt['pillar.get']('openclaw:claude_bridge:repo') }}
-    - target: /home/deploy/apps/openclaw-claude-bridge
-    - rev: {{ salt['pillar.get']('openclaw:claude_bridge:rev') }}
-    - user: deploy
-    - force_fetch: True
-    - force_checkout: True
+  cmd.run:
+    - name: git clone https://github.com/shinglokto/openclaw-claude-bridge.git /home/deploy/apps/openclaw-claude-bridge && git -C /home/deploy/apps/openclaw-claude-bridge checkout c828f45bfc7a8690487a1b06d0dec591b9857fcf
+    - runas: deploy
+    - creates: /home/deploy/apps/openclaw-claude-bridge/.git
     - require:
       - file: /home/deploy/apps/openclaw-claude-bridge
 
@@ -34,8 +31,7 @@ openclaw-claude-bridge-install:
     - name: npm ci
     - cwd: /home/deploy/apps/openclaw-claude-bridge
     - runas: deploy
-    - onchanges:
-      - git: openclaw-claude-bridge-repo
+    - creates: /home/deploy/apps/openclaw-claude-bridge/node_modules
     - env:
         HOME: /home/deploy
         PATH: /home/deploy/.local/bin:/usr/local/bin:/usr/bin:/bin
@@ -69,10 +65,8 @@ openclaw-claude-bridge-service-restart:
   cmd.run:
     - name: systemctl restart openclaw-claude-bridge.service
     - onchanges:
-      - git: openclaw-claude-bridge-repo
       - file: /home/deploy/apps/openclaw-claude-bridge/.env
       - file: /etc/systemd/system/openclaw-claude-bridge.service
-      - cmd: openclaw-claude-bridge-install
     - require:
       - service: openclaw-claude-bridge-service-enabled
       - cmd: openclaw-claude-bridge-systemd-daemon-reload

--- a/salt/openclaw/init.sls
+++ b/salt/openclaw/init.sls
@@ -1,0 +1,78 @@
+/home/deploy/apps/openclaw-claude-bridge:
+  file.directory:
+    - user: deploy
+    - group: deploy
+    - mode: "0755"
+    - makedirs: True
+    - require:
+      - user: deploy
+
+openclaw-claude-bridge-repo:
+  git.latest:
+    - name: {{ salt['pillar.get']('openclaw:claude_bridge:repo') }}
+    - target: /home/deploy/apps/openclaw-claude-bridge
+    - rev: {{ salt['pillar.get']('openclaw:claude_bridge:rev') }}
+    - user: deploy
+    - force_fetch: True
+    - force_checkout: True
+    - require:
+      - file: /home/deploy/apps/openclaw-claude-bridge
+
+/home/deploy/apps/openclaw-claude-bridge/.env:
+  file.managed:
+    - source: salt://openclaw/bridge.env.j2
+    - template: jinja
+    - user: deploy
+    - group: deploy
+    - mode: "0600"
+    - show_changes: false
+    - require:
+      - git: openclaw-claude-bridge-repo
+
+openclaw-claude-bridge-install:
+  cmd.run:
+    - name: npm ci
+    - cwd: /home/deploy/apps/openclaw-claude-bridge
+    - runas: deploy
+    - onchanges:
+      - git: openclaw-claude-bridge-repo
+    - env:
+        HOME: /home/deploy
+        PATH: /home/deploy/.local/bin:/usr/local/bin:/usr/bin:/bin
+    - require:
+      - pkg: nodejs
+      - git: openclaw-claude-bridge-repo
+
+/etc/systemd/system/openclaw-claude-bridge.service:
+  file.managed:
+    - source: salt://openclaw/openclaw-claude-bridge.service
+    - user: root
+    - group: root
+    - mode: "0644"
+
+openclaw-claude-bridge-systemd-daemon-reload:
+  cmd.run:
+    - name: systemctl daemon-reload
+    - onchanges:
+      - file: /etc/systemd/system/openclaw-claude-bridge.service
+
+openclaw-claude-bridge-service-enabled:
+  service.enabled:
+    - name: openclaw-claude-bridge
+    - require:
+      - file: /etc/systemd/system/openclaw-claude-bridge.service
+      - file: /home/deploy/apps/openclaw-claude-bridge/.env
+      - cmd: openclaw-claude-bridge-install
+      - cmd: openclaw-claude-bridge-systemd-daemon-reload
+
+openclaw-claude-bridge-service-restart:
+  cmd.run:
+    - name: systemctl restart openclaw-claude-bridge.service
+    - onchanges:
+      - git: openclaw-claude-bridge-repo
+      - file: /home/deploy/apps/openclaw-claude-bridge/.env
+      - file: /etc/systemd/system/openclaw-claude-bridge.service
+      - cmd: openclaw-claude-bridge-install
+    - require:
+      - service: openclaw-claude-bridge-service-enabled
+      - cmd: openclaw-claude-bridge-systemd-daemon-reload

--- a/salt/openclaw/openclaw-claude-bridge.service
+++ b/salt/openclaw/openclaw-claude-bridge.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=OpenClaw Claude Bridge
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=deploy
+Group=deploy
+WorkingDirectory=/home/deploy/apps/openclaw-claude-bridge
+Environment=PATH=/home/deploy/.local/bin:/usr/local/bin:/usr/bin:/bin
+EnvironmentFile=/home/deploy/apps/openclaw-claude-bridge/.env
+ExecStart=/usr/bin/node src/index.js
+KillMode=process
+TimeoutStopSec=180
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/salt/openclaw/openclaw-claude-bridge.service
+++ b/salt/openclaw/openclaw-claude-bridge.service
@@ -12,7 +12,7 @@ Environment=PATH=/home/deploy/.local/bin:/usr/local/bin:/usr/bin:/bin
 EnvironmentFile=/home/deploy/apps/openclaw-claude-bridge/.env
 ExecStart=/usr/bin/node src/index.js
 KillMode=process
-TimeoutStopSec=180
+TimeoutStopSec=30
 Restart=always
 RestartSec=5
 StandardOutput=journal


### PR DESCRIPTION
## Summary
- add a reusable Salt state to deploy the openclaw-claude-bridge service as deploy on bertrand
- add encrypted dashboard auth and host pillar config for the pinned upstream revision
- expose the bridge API and dashboard under claude-bridge.khumbu.namche.ai via nginx

## Validation
- git diff --check
- unable to run salt-call locally in this workspace (binary not installed)
- unable to run systemd-analyze locally in this workspace (binary not installed)