### PR TITLE
bertrand: re-encrypt openclaw dashboard secret

### DIFF
--- a/pillar/secrets.sls
+++ b/pillar/secrets.sls
@@ -142,19 +142,19 @@ secrets:
           -----BEGIN PGP MESSAGE-----
           Comment: GPGTools - http://gpgtools.org
 
-          hQIMA0QvKRCOLt9nARAAyI9oncUFEmdF9qaQ7OXZBwLyeBVqHiuROwAgpV08cm2u
-          Jfachhw9/eSX4g/mwFbdu6/ln/bhfDKBvmZgAXgJQk9QJCQ7tD6YqTSkBjdnRo+8
-          ohUsRpvJ2DPGXc9+S4JHQFDJSeQUXePujRdWmYC1xmO5LqmMKhMQtto8fTB4Ng46
-          ta6A7D91WGCxMMI6DROC0xqlzmXiSLPweCbtVp1HGJnK7neVc1+xW3SXIQztyimR
-          tf4cdVb0gjrWA0x3jfuKkxg1++jxYcyBGOUSwsV/Gyh/iKuXxXo2I3nVG6z3KNvj
-          VwHdktlKW6f5aW/epXo9Holk3ZdBLVqZ/TJFMpZhVPfq/TcsgRnBtW6W98LRbk4X
-          k1okA0/NJ7S7gsx928rhxoGqPDaiSFgR4nbC48KaonuguYP0TfZa+bYDchj4+3Z8
-          B0mm8SFJpTXPSKzlF+w5CD0U9PIOKEhg3EsQEAsGlfKqXQXQFpxxPDoMjOxJ76BW
-          qE9FYTTzWHIAZP/aMlpSwo2PqYv05l5zf/B74ztKGDacAALmjbp/KCj3B0NMr4Et
-          20x8lI/uNDVB8jH54nQputDcOOw+ldU0JSVh8/mCBc2Z7WBxxq2y3rIW61ZV9Xmy
-          Bg9vWD0qZsAog+pRpo4um12t/6qgD1KbSCuBV6qKTnJHVNad/blfF+Gejdy5xFzS
-          dgE/iiLQqI9A4HPa+Mblg5n6HTNUHRLmi9B2N7IgHTOLF0nqCTCnmpfQbX6Kq0OS
-          wzze+zTNMol72E4kb0E/JfmDGNWQy32JMKPR4hnfS5n1u9Dul4lGZ3L5Z31MrUcn
-          dLXNasD2DKqFxwv6kBTm5XR9kYREHRg=
-          =MuNT
+          hQIMA5ZHxiCsLfFyAQ/9G9OZYmYJtdjwGOHvyK7XuqStm070qT9hLXXTUA6bvqtG
+          uk/rAW5tal+3Ec5zCdoE9+9enxn9r9W2d6ay7zZNGhx6v1BwfQNXGT2sU9AJcsn4
+          tiwto9D/UVq4GFLvFhDZhyR16lxgU5qW2ov2Ph9irrHW74sxoiTN7BuMIY/ZINqm
+          iKzNbDOMmFgzmXDU9wo9GyzLEkkxgkWOafgjbhqFYdRLdtTbNelx766yJZLTPPPF
+          7SM+HLdR96kwYJmfjBpN9DPEXweJciEPYjRIkUSd7dmU2hYi0SHeaG5hXYe21l9o
+          ovvNZ5lvHdruZMWMSuGRPO3ij8IteDsWgGBBI7tPVXVxGq/MPhY2wSanCWEYrqJQ
+          cRjAKs050BEGCEhLuOizRilTvqPKbyfivulB1yhUqOSaKVqgHLbdFpvZLuezYZQY
+          1MAIp42V45iEuTovc9MvpsS/Vv8kkjuP2M/leEXQxasOhe1fbc+mQ0xVHHkpP9Vr
+          SusGaMBY4vfGC+EdsXgrhQVV7x2/qtr5MpMYHFzWDLvmhqXwIsz+qTziUHSkColE
+          PiwJTTWE/eVqNzawGQpbIEhFyJvQEolpsw1CIxbZ9cQkzzt4i0BfSZwE9xF5xv2s
+          R50Jc8JTFa8itUGwv+0I7sUhfG8eJRrXbE5upmXgWlIOj4MKx0DoUgKWFeH9XsPU
+          gAEJAhBfEXiJF3tZYY9eRbB86JKae+4oVjg6NEpUPf1nOJj7Vsizw+J88asjajlr
+          ek56nQtcwl0GLHXMa/5elnnu/VTLyHUb/ydd/wcO5MSxpOQsRewJO4GAwm/xLSeY
+          Oa87InXZzP+mzN7p2OYwwPaqYsyIYnoaVNpro03cuDqv
+          =PzIB
           -----END PGP MESSAGE-----


### PR DESCRIPTION
## Summary
- re-encrypt the openclaw dashboard password to the existing sysadmin GPG recipient used by deployed Salt hosts
- fix the post-merge Salt pillar render failure on bertrand and hinault

## Validation
- git diff --check
- verified the new ciphertext targets recipient key 9647C620AC2DF172 (BTLG | sysadmin) with gpg --list-packets
- root cause confirmed from merged workflow logs: hosts could not decrypt the previous ciphertext encrypted to 442F29108E2EDF67