### PR TITLE
bertrand: fix honcho service start ordering

### DIFF
--- a/salt/apps/honcho/init.sls
+++ b/salt/apps/honcho/init.sls
@@ -60,3 +60,5 @@ honcho-service-restart:
       - pkg: docker
       - service: honcho-service-enabled
       - cmd: honcho-systemd-daemon-reload
+      - cmd: postgres-restart
+      - cmd: redis-restart


### PR DESCRIPTION
## Summary

- Fix race condition where `honcho-service-restart` ran before postgres/redis were configured for Docker bridge connections
- Add `require` on `postgres-restart` and `redis-restart` to ensure proper ordering

The first deploy failed because `docker compose up` tried to start honcho before PostgreSQL was listening on the Docker bridge network.

## Test plan
- [ ] Re-run salt apply — honcho should start successfully after postgres and redis are ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)