### PR TITLE
bertrand: require honcho DB setup before service start

### DIFF
--- a/salt/apps/honcho/init.sls
+++ b/salt/apps/honcho/init.sls
@@ -62,3 +62,4 @@ honcho-service-restart:
       - cmd: honcho-systemd-daemon-reload
       - cmd: postgres-restart
       - cmd: redis-restart
+      - cmd: honcho-db-pgvector


### PR DESCRIPTION
## Summary

- Add `require: honcho-db-pgvector` to `honcho-service-restart` so the service only starts after the database user, database, and pgvector extension are fully provisioned
- This chains through: `honcho-db-pgvector` → `honcho-db` → `honcho-db-user`
- Previous runs showed the service restart firing *before* the password was updated (timestamps confirmed parallel execution)

## Test plan
- [ ] Salt apply succeeds with 0 failures
- [ ] honcho containers connect to postgres successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)