### PR TITLE
bertrand: force honcho restart to pick up corrected password

### DIFF
--- a/salt/apps/honcho/env.j2
+++ b/salt/apps/honcho/env.j2
@@ -1,4 +1,5 @@
 # Honcho environment configuration
+
 # Database - connects to host PostgreSQL via Docker host gateway
 {%- set db_password = salt['pillar.get']('secrets:vault:honcho:db_password') | trim | urlencode %}
 DB_CONNECTION_URI=postgresql+psycopg://honcho:{{ db_password }}@host.docker.internal:5432/honcho


### PR DESCRIPTION
## Summary

- Trigger `.env` file change so `onchanges` fires and restarts the honcho containers
- The PG password was fixed in #55 (trim + refresh_password), but the containers were never restarted to pick up the new `.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)