### PR TITLE
bertrand: fix honcho DB password encoding mismatch

### DIFF
--- a/salt/apps/honcho/env.j2
+++ b/salt/apps/honcho/env.j2
@@ -1,7 +1,6 @@
 # Honcho environment configuration
 # Database - connects to host PostgreSQL via Docker host gateway
-{%- set db_password = salt['pillar.get']('secrets:vault:honcho:db_password') | trim | urlencode %}
-DB_CONNECTION_URI=postgresql+psycopg://honcho:{{ db_password }}@host.docker.internal:5432/honcho
+DB_CONNECTION_URI=postgresql+psycopg://honcho:{{ salt['pillar.get']('secrets:vault:honcho:db_password') | trim }}@host.docker.internal:5432/honcho
 
 # Cache - connects to host Redis via Docker host gateway
 CACHE_URL=redis://host.docker.internal:6379/0

--- a/salt/hosts/bertrand/honcho-db.sls
+++ b/salt/hosts/bertrand/honcho-db.sls
@@ -4,6 +4,7 @@ honcho-db-user:
   postgres_user.present:
     - name: honcho
     - password: "{{ salt['pillar.get']('secrets:vault:honcho:db_password') | trim }}"
+    - encrypted: False
     - login: True
     - refresh_password: True
     - require:


### PR DESCRIPTION
## Summary

- **Drop `| urlencode`** from DB password in the connection URI — the raw password is passed directly, avoiding any encoding transformation mismatch between what psycopg sends and what PG expects
- **Add `encrypted: False`** to `postgres_user.present` so Salt passes the plaintext password to PostgreSQL, letting PG hash it with `scram-sha-256` (instead of Salt potentially pre-hashing it as md5, which won't work with our `scram-sha-256` pg_hba.conf entry)

These two changes together ensure the exact same plaintext password is stored in PG and sent by the honcho container.

## Test plan
- [ ] Salt apply succeeds
- [ ] honcho containers connect to postgres without auth errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)