### PR TITLE
bertrand: set honcho DB password via ALTER ROLE directly

### DIFF
--- a/salt/apps/honcho/init.sls
+++ b/salt/apps/honcho/init.sls
@@ -63,3 +63,4 @@ honcho-service-restart:
       - cmd: postgres-restart
       - cmd: redis-restart
       - postgres_extension: honcho-db-pgvector
+      - cmd: honcho-db-user-password

--- a/salt/hosts/bertrand/honcho-db.sls
+++ b/salt/hosts/bertrand/honcho-db.sls
@@ -3,12 +3,15 @@
 honcho-db-user:
   postgres_user.present:
     - name: honcho
-    - password: "{{ salt['pillar.get']('secrets:vault:honcho:db_password') | trim }}"
-    - encrypted: False
     - login: True
-    - refresh_password: True
     - require:
       - service: postgresql-service
+
+honcho-db-user-password:
+  cmd.run:
+    - name: sudo -u postgres psql -c "ALTER ROLE honcho WITH PASSWORD '{{ salt['pillar.get']('secrets:vault:honcho:db_password') | trim }}';"
+    - require:
+      - postgres_user: honcho-db-user
 
 honcho-db:
   postgres_database.present:


### PR DESCRIPTION
## Summary

- Remove password management from `postgres_user.present` (remove `password`, `encrypted`, `refresh_password`) — Salt's state has compatibility issues with `scram-sha-256` auth
- Set password via direct `ALTER ROLE honcho WITH PASSWORD '...'` using `cmd.run` — PostgreSQL handles the hashing correctly with whatever `password_encryption` is configured
- Add require on `honcho-db-user-password` in `honcho-service-restart` to maintain ordering

## Test plan
- [ ] Salt apply succeeds (no "Failed to update user" error)
- [ ] `ALTER ROLE` sets password with scram-sha-256
- [ ] honcho containers connect to postgres successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)