### PR TITLE
bertrand: revert encrypted: False from honcho postgres_user

### DIFF
--- a/salt/hosts/bertrand/honcho-db.sls
+++ b/salt/hosts/bertrand/honcho-db.sls
@@ -4,7 +4,6 @@ honcho-db-user:
   postgres_user.present:
     - name: honcho
     - password: "{{ salt['pillar.get']('secrets:vault:honcho:db_password') | trim }}"
-    - encrypted: False
     - login: True
     - refresh_password: True
     - require:


### PR DESCRIPTION
## Summary

- Remove `encrypted: False` from `postgres_user.present` which caused "Failed to update user honcho" (PG 10+ removed `UNENCRYPTED PASSWORD` support)
- Use the default state behavior: Salt manages the password hash, `refresh_password: True` ensures it stays in sync with the pillar value
- The underlying auth mismatch was the `| urlencode` in env.j2, already fixed in #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)