### PR TITLE
bertrand: fix honcho password, add migrations, enable cache

### DIFF
--- a/salt/apps/honcho/docker-compose.yml
+++ b/salt/apps/honcho/docker-compose.yml
@@ -17,6 +17,15 @@ services:
       retries: 5
       start_period: 60s
 
+  migrate:
+    container_name: honcho-migrate
+    image: ghcr.io/plastic-labs/honcho:${HONCHO_VERSION:-latest}
+    env_file: ./.env
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: ["alembic", "upgrade", "head"]
+    restart: "no"
+
   deriver:
     container_name: honcho-deriver
     image: ghcr.io/plastic-labs/honcho:${HONCHO_VERSION:-latest}
@@ -28,3 +37,5 @@ services:
     depends_on:
       api:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully

--- a/salt/apps/honcho/env.j2
+++ b/salt/apps/honcho/env.j2
@@ -3,6 +3,7 @@
 DB_CONNECTION_URI=postgresql+psycopg://honcho:{{ salt['pillar.get']('secrets:vault:honcho:db_password') | trim }}@host.docker.internal:5432/honcho
 
 # Cache - connects to host Redis via Docker host gateway
+CACHE_ENABLED=true
 CACHE_URL=redis://host.docker.internal:6379/0
 
 # Authentication

--- a/salt/apps/honcho/init.sls
+++ b/salt/apps/honcho/init.sls
@@ -63,4 +63,3 @@ honcho-service-restart:
       - cmd: postgres-restart
       - cmd: redis-restart
       - postgres_extension: honcho-db-pgvector
-      - cmd: honcho-db-password

--- a/salt/apps/honcho/init.sls
+++ b/salt/apps/honcho/init.sls
@@ -63,3 +63,4 @@ honcho-service-restart:
       - cmd: postgres-restart
       - cmd: redis-restart
       - postgres_extension: honcho-db-pgvector
+      - cmd: honcho-db-password

--- a/salt/hosts/bertrand/honcho-db.sls
+++ b/salt/hosts/bertrand/honcho-db.sls
@@ -3,19 +3,12 @@
 honcho-db-user:
   postgres_user.present:
     - name: honcho
+    - password: "{{ salt['pillar.get']('secrets:vault:honcho:db_password') | trim }}"
+    - encrypted: scram-sha-256
     - login: True
+    - refresh_password: True
     - require:
       - service: postgresql-service
-
-# Set password via ALTER ROLE so PostgreSQL hashes it with scram-sha-256.
-# Salt's postgres_user.present pre-hashes as md5, which is incompatible
-# with scram-sha-256 auth in pg_hba.conf.
-honcho-db-password:
-  cmd.run:
-    - name: sudo -u postgres psql -c "ALTER ROLE honcho WITH PASSWORD '{{ salt['pillar.get']('secrets:vault:honcho:db_password') | trim }}';"
-    - unless: PGPASSWORD='{{ salt['pillar.get']('secrets:vault:honcho:db_password') | trim }}' psql -h localhost -U honcho -d postgres -tAc 'SELECT 1' 2>/dev/null | grep -q 1
-    - require:
-      - postgres_user: honcho-db-user
 
 honcho-db:
   postgres_database.present:

--- a/salt/hosts/bertrand/honcho-db.sls
+++ b/salt/hosts/bertrand/honcho-db.sls
@@ -3,11 +3,19 @@
 honcho-db-user:
   postgres_user.present:
     - name: honcho
-    - password: "{{ salt['pillar.get']('secrets:vault:honcho:db_password') | trim }}"
     - login: True
-    - refresh_password: True
     - require:
       - service: postgresql-service
+
+# Set password via ALTER ROLE so PostgreSQL hashes it with scram-sha-256.
+# Salt's postgres_user.present pre-hashes as md5, which is incompatible
+# with scram-sha-256 auth in pg_hba.conf.
+honcho-db-password:
+  cmd.run:
+    - name: sudo -u postgres psql -c "ALTER ROLE honcho WITH PASSWORD '{{ salt['pillar.get']('secrets:vault:honcho:db_password') | trim }}';"
+    - unless: PGPASSWORD='{{ salt['pillar.get']('secrets:vault:honcho:db_password') | trim }}' psql -h localhost -U honcho -d postgres -tAc 'SELECT 1' 2>/dev/null | grep -q 1
+    - require:
+      - postgres_user: honcho-db-user
 
 honcho-db:
   postgres_database.present:


### PR DESCRIPTION
## Summary

- **Password**: Set via `ALTER ROLE` with an `unless` guard that tests the actual connection. Salt's `postgres_user.present` pre-hashes as md5 which is incompatible with `scram-sha-256` auth in our pg_hba.conf. The `postgres_user.present` state still manages user creation/login, password is handled separately.
- **Migrations**: Add a `migrate` service to docker-compose that runs `alembic upgrade head` before the deriver starts. This ensures schema is always up to date on deploy.
- **Redis cache**: Add `CACHE_ENABLED=true` to env — Honcho defaults to disabled.

## Test plan
- [ ] Salt apply succeeds, password set correctly
- [ ] `honcho-migrate` container runs migrations and exits 0
- [ ] `honcho-api` and `honcho-deriver` start without errors
- [ ] Cache log shows "Connected to cache" instead of "Cache disabled"

🤖 Generated with [Claude Code](https://claude.com/claude-code)