### PR TITLE
make deploy user and honcho-db-user states idempotent

### DIFF
--- a/salt/common/infra.sls
+++ b/salt/common/infra.sls
@@ -5,9 +5,10 @@ deploy:
   user.present:
     - shell: /bin/bash
     - home: /home/deploy
-    - optional_groups:
+    - groups:
       - infra
       - www-data
+    - remove_groups: False
     - createhome: True
     - require:
       - group: infra

--- a/salt/hosts/bertrand/honcho-db.sls
+++ b/salt/hosts/bertrand/honcho-db.sls
@@ -6,7 +6,6 @@ honcho-db-user:
     - password: "{{ salt['pillar.get']('secrets:vault:honcho:db_password') | trim }}"
     - encrypted: scram-sha-256
     - login: True
-    - refresh_password: True
     - require:
       - service: postgresql-service
 


### PR DESCRIPTION
## Summary

- **deploy user**: Switch from `optional_groups` to `groups` with `remove_groups: False`. `optional_groups` was stripping the `docker` group on each run, then the docker `group.present` re-added it — causing both states to report changes every apply.
- **honcho-db-user**: Remove `refresh_password: True`. With `scram-sha-256`, each hash computation uses a random salt, so Salt always sees a "different" password and updates it on every run.

After this change, a clean `state.highstate` should show `Succeeded: 0 (changed=0)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)