### PR TITLE
bertrand: add paperclip to salt

### DIFF
--- a/pillar/secrets.sls
+++ b/pillar/secrets.sls
@@ -282,3 +282,45 @@ secrets:
         PCbT1lFJWb3vGFtfcUxqEwW7X8dBx5ENOz0OKx4pwBHsS/NJvE4=
         =mkmS
         -----END PGP MESSAGE-----
+    paperclip:
+      db_password: |
+        -----BEGIN PGP MESSAGE-----
+        Comment: GPGTools - http://gpgtools.org
+
+        hQIMA5ZHxiCsLfFyARAApPgrPrI4uvxiB9y6SW3V93vsy8p1ip1YThYFHDgbJ2Us
+        FUi3xcug/IjZ3DtqsnaXwKZU/hI3EHeaqpZA5Ros0Z8GcSic1z4ttqdCdzSTxmYr
+        +SLvMmW5dY4W/gcSVx6Lks6WeGZ68RdqpuL0wV9rRLZp8pWee+xvPscw8RjYNBnF
+        3FL/A1ZunfnA62/GD3tXrleJ+XS39QXPctyzY8lKzCTmR0O/xTUEnc2gaDDHG7K6
+        kM9jYkDIs1Oj2lCzICcsI/YN32JyXCTGSiUnp1OMl6I1DQefZAtiy45Z4n/ZmGKh
+        aERFFh+i7FCIVh+MSttsfh/HrALqMlh+ONbw5Glez1A2go5VA63nFMzZ241ojAGU
+        0Q8s/VrNpmC6Xf+YWUvrK0rtuLgowCb1aUb6HiHczVULprMLS9Sf4RvqWrDeilnI
+        Z4npuvEI5fqngo/PcwnecxVCcY5gIA1JlgSBKNHws1KxDisHCNuZNNU/mwxRk+yM
+        EyRwJSCh0dXatpy/rw8OB16lod/jSY6yWcjLSVuippNLILPjjnWlR1wv/2YptkGP
+        CMVxCnqT0pMaCvCienta/PqedHYX/84WNMRTZMMD97ph5GXAbVzbZp1KRIdMFXCH
+        ieNxhgeooD4IYDhqioMhQT6Ah2T3/46W0GuIYdzwWXY9oVou3AJfGoHsqoUza6jU
+        cgEJAhDI1dPyYXx3cUg3Yu2oVW4nHTWrLydlPnEXxPZTdwQJ9Pw9bGzFdG2S7VrP
+        dQv0oOSr9dekU2ztl6EBCsXZ7hh5HwUW8+RYU42Tp4MdNdwPeJaNQsHaqLQEUiav
+        W3f6aTHBRkGfy3pmdGhDkYGfPg==
+        =kajr
+        -----END PGP MESSAGE-----
+      better_auth_secret: |
+        -----BEGIN PGP MESSAGE-----
+        Comment: GPGTools - http://gpgtools.org
+
+        hQIMA5ZHxiCsLfFyAQ/+JpJ+M4fZ8uaeota20rGcInMQO9w+uBUu4Kx/qjOZX34v
+        Lf3xunJpgMHtWcxCyH4MoMKr8n/rP68nAuvLw3HBqqMTkJlzkoaYBRdCQlzSUpTu
+        cv+9336yHC0JOX2/LD9OBynTZvatklw6XGrDyhhkG0TLtGgNpv23E3CbZgad297+
+        8wD5s168ffDFBXnBXhWuFFILFrdLYdKvlhTrmjLxM6rbNZIw1fmU/vbkRPAk4+3g
+        UtsqDxyMRSlddBOYhJfGcFUk+PSWvX69sXhu2uKFp4N06yppaKjPB0YLf8cYUO0G
+        jTYjO2Bs8pdBlV/CjOz3pVX2ifKtEAaAgVmtp825Wp8nQntZmE92HzqA3jB4fc7z
+        KpwFsq/5tJ/19QE19HIu26agfInDngCPle+UJsqmist1vp/LStlombHEL4VMJzNz
+        MdbtFMTx3An+zEX44hOq+0qL/SYs/o2wOpKfMf1kqWnA0iUH3jwP6mm2LctogKYC
+        SwWBHqiOq5buRgIDTw9vUo4MVUCdOkW7fgCCSGXLFdgxiez5GI4XPEZgrFjxCcZf
+        0OcMsC3npkFV69cO+pkxBoh1SieHUr+i+EkMshq4w28of6m6D77aQjGKhqT3TRMz
+        zNZmORw8KNkOIZ6UjHpnvzTgXosTk0N3biEHLOL0KVHKA89aU4CQ25Tcl4gf22HU
+        nAEJAhC9A301x2ki3weyI3mDkP3TgmnQ5JcDVRbTtWEhilPQFpDJJ1ErRCa8EdxF
+        ZtH0FayoXmAbDJPXYO2CobDPMLnyE8q3ej/fZGIm66SEqyQiKuFgEyIhh8eIOF0v
+        IKw5TH8l15ISRGf4N5qr2btRerv2ga7CZNYRFPgiH2ezEBcrLpRo1/TMqe8KUaOq
+        FVmgSTAmbw6QozpDgQ==
+        =nxVm
+        -----END PGP MESSAGE-----

--- a/salt/apps/paperclip/docker-compose.custom.yml
+++ b/salt/apps/paperclip/docker-compose.custom.yml
@@ -3,7 +3,7 @@ name: paperclip
 services:
   server:
     build:
-      context: /home/deploy/apps/paperclip
+      context: ..
       dockerfile: Dockerfile
     container_name: paperclip-server
     restart: always
@@ -12,5 +12,3 @@ services:
     env_file: ./.env
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    volumes:
-      - /srv/paperclip:/paperclip

--- a/salt/apps/paperclip/docker-compose.yml
+++ b/salt/apps/paperclip/docker-compose.yml
@@ -1,0 +1,16 @@
+name: paperclip
+
+services:
+  server:
+    build:
+      context: /home/deploy/apps/paperclip
+      dockerfile: Dockerfile
+    container_name: paperclip-server
+    restart: always
+    ports:
+      - "127.0.0.1:3100:3100"
+    env_file: ./.env
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - /srv/paperclip:/paperclip

--- a/salt/apps/paperclip/env.j2
+++ b/salt/apps/paperclip/env.j2
@@ -1,0 +1,7 @@
+DATABASE_URL=postgres://paperclip:{{ salt['pillar.get']('secrets:vault:paperclip:db_password') | trim }}@host.docker.internal:5432/paperclip
+PAPERCLIP_DEPLOYMENT_MODE=authenticated
+PAPERCLIP_DEPLOYMENT_EXPOSURE=public
+PAPERCLIP_PUBLIC_URL=https://paperclip.namche.ai
+BETTER_AUTH_SECRET={{ salt['pillar.get']('secrets:vault:paperclip:better_auth_secret') | trim }}
+PORT=3100
+SERVE_UI=true

--- a/salt/apps/paperclip/init.sls
+++ b/salt/apps/paperclip/init.sls
@@ -6,22 +6,14 @@ paperclip-repo:
     - require:
       - user: deploy
 
-/home/deploy/apps/paperclip/docker:
-  file.directory:
-    - user: deploy
-    - group: deploy
-    - mode: "0755"
-    - require:
-      - git: paperclip-repo
-
-/home/deploy/apps/paperclip/docker/docker-compose.yml:
+/home/deploy/apps/paperclip/docker/docker-compose.custom.yml:
   file.managed:
-    - source: salt://apps/paperclip/docker-compose.yml
+    - source: salt://apps/paperclip/docker-compose.custom.yml
     - user: deploy
     - group: deploy
     - mode: "0644"
     - require:
-      - file: /home/deploy/apps/paperclip/docker
+      - git: paperclip-repo
 
 /home/deploy/apps/paperclip/docker/.env:
   file.managed:
@@ -32,14 +24,7 @@ paperclip-repo:
     - mode: "0600"
     - show_changes: false
     - require:
-      - file: /home/deploy/apps/paperclip/docker
-
-/srv/paperclip:
-  file.directory:
-    - user: deploy
-    - group: deploy
-    - mode: "0755"
-    - makedirs: True
+      - git: paperclip-repo
 
 /etc/systemd/system/paperclip.service:
   file.managed:
@@ -58,7 +43,7 @@ paperclip-service-enabled:
   service.enabled:
     - name: paperclip
     - require:
-      - file: /home/deploy/apps/paperclip/docker/docker-compose.yml
+      - file: /home/deploy/apps/paperclip/docker/docker-compose.custom.yml
       - file: /home/deploy/apps/paperclip/docker/.env
       - file: /etc/systemd/system/paperclip.service
       - cmd: paperclip-systemd-daemon-reload
@@ -67,7 +52,7 @@ paperclip-service-restart:
   cmd.run:
     - name: systemctl restart paperclip.service
     - onchanges:
-      - file: /home/deploy/apps/paperclip/docker/docker-compose.yml
+      - file: /home/deploy/apps/paperclip/docker/docker-compose.custom.yml
       - file: /home/deploy/apps/paperclip/docker/.env
       - file: /etc/systemd/system/paperclip.service
     - require:
@@ -75,5 +60,4 @@ paperclip-service-restart:
       - service: paperclip-service-enabled
       - cmd: paperclip-systemd-daemon-reload
       - cmd: postgres-restart
-      - file: /srv/paperclip
       - postgres_database: paperclip-db

--- a/salt/apps/paperclip/init.sls
+++ b/salt/apps/paperclip/init.sls
@@ -1,0 +1,79 @@
+paperclip-repo:
+  git.cloned:
+    - name: https://github.com/paperclipai/paperclip.git
+    - target: /home/deploy/apps/paperclip
+    - user: deploy
+    - require:
+      - user: deploy
+
+/home/deploy/apps/paperclip/docker:
+  file.directory:
+    - user: deploy
+    - group: deploy
+    - mode: "0755"
+    - require:
+      - git: paperclip-repo
+
+/home/deploy/apps/paperclip/docker/docker-compose.yml:
+  file.managed:
+    - source: salt://apps/paperclip/docker-compose.yml
+    - user: deploy
+    - group: deploy
+    - mode: "0644"
+    - require:
+      - file: /home/deploy/apps/paperclip/docker
+
+/home/deploy/apps/paperclip/docker/.env:
+  file.managed:
+    - source: salt://apps/paperclip/env.j2
+    - template: jinja
+    - user: deploy
+    - group: deploy
+    - mode: "0600"
+    - show_changes: false
+    - require:
+      - file: /home/deploy/apps/paperclip/docker
+
+/srv/paperclip:
+  file.directory:
+    - user: deploy
+    - group: deploy
+    - mode: "0755"
+    - makedirs: True
+
+/etc/systemd/system/paperclip.service:
+  file.managed:
+    - source: salt://apps/paperclip/paperclip.service
+    - user: root
+    - group: root
+    - mode: "0644"
+
+paperclip-systemd-daemon-reload:
+  cmd.run:
+    - name: systemctl daemon-reload
+    - onchanges:
+      - file: /etc/systemd/system/paperclip.service
+
+paperclip-service-enabled:
+  service.enabled:
+    - name: paperclip
+    - require:
+      - file: /home/deploy/apps/paperclip/docker/docker-compose.yml
+      - file: /home/deploy/apps/paperclip/docker/.env
+      - file: /etc/systemd/system/paperclip.service
+      - cmd: paperclip-systemd-daemon-reload
+
+paperclip-service-restart:
+  cmd.run:
+    - name: systemctl restart paperclip.service
+    - onchanges:
+      - file: /home/deploy/apps/paperclip/docker/docker-compose.yml
+      - file: /home/deploy/apps/paperclip/docker/.env
+      - file: /etc/systemd/system/paperclip.service
+    - require:
+      - pkg: docker
+      - service: paperclip-service-enabled
+      - cmd: paperclip-systemd-daemon-reload
+      - cmd: postgres-restart
+      - file: /srv/paperclip
+      - postgres_database: paperclip-db

--- a/salt/apps/paperclip/paperclip.service
+++ b/salt/apps/paperclip/paperclip.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Paperclip (Docker Compose)
+After=network-online.target docker.service postgresql.service
+Wants=network-online.target
+Requires=docker.service
+
+[Service]
+Type=oneshot
+User=deploy
+Group=deploy
+WorkingDirectory=/home/deploy/apps/paperclip/docker
+RemainAfterExit=yes
+ExecStart=/usr/bin/docker compose up -d --build
+ExecStop=/usr/bin/docker compose down
+ExecReload=/usr/bin/docker compose up -d --build
+TimeoutStartSec=0
+
+[Install]
+WantedBy=multi-user.target

--- a/salt/apps/paperclip/paperclip.service
+++ b/salt/apps/paperclip/paperclip.service
@@ -10,9 +10,9 @@ User=deploy
 Group=deploy
 WorkingDirectory=/home/deploy/apps/paperclip/docker
 RemainAfterExit=yes
-ExecStart=/usr/bin/docker compose up -d --build
-ExecStop=/usr/bin/docker compose down
-ExecReload=/usr/bin/docker compose up -d --build
+ExecStart=/usr/bin/docker compose -f docker-compose.custom.yml up -d --build
+ExecStop=/usr/bin/docker compose -f docker-compose.custom.yml down
+ExecReload=/usr/bin/docker compose -f docker-compose.custom.yml up -d --build
 TimeoutStartSec=0
 
 [Install]

--- a/salt/hosts/bertrand/init.sls
+++ b/salt/hosts/bertrand/init.sls
@@ -1,9 +1,11 @@
 include:
   - apps.api-proxy
   - apps.honcho
+  - apps.paperclip
   - apps.searxng
   - hosts.bertrand.deploy
   - hosts.bertrand.honcho-db
+  - hosts.bertrand.paperclip-db
   - hosts.bertrand.volumes
   - docker
   - letsencrypt

--- a/salt/hosts/bertrand/init.sls
+++ b/salt/hosts/bertrand/init.sls
@@ -58,6 +58,12 @@ include:
   - require:
     - cmd: /etc/letsencrypt/live/khumbu.namche.ai/fullchain.pem
 
+/etc/nginx/conf.d/paperclip.namche.ai.conf:
+  file.managed:
+  - source: salt://hosts/bertrand/paperclip.namche.ai.conf
+  - require:
+    - file: /etc/nginx/certs/namche.ai.cloudflare-origin.crt
+
 nginx-reload:
   cmd.run:
   - name: systemctl try-restart nginx.service
@@ -68,3 +74,4 @@ nginx-reload:
     - file: /etc/nginx/conf.d/khumbu.namche.ai.conf
     - file: /etc/nginx/conf.d/claude-bridge.khumbu.namche.ai.conf
     - file: /etc/nginx/conf.d/honcho.khumbu.namche.ai.conf
+    - file: /etc/nginx/conf.d/paperclip.namche.ai.conf

--- a/salt/hosts/bertrand/paperclip-db.sls
+++ b/salt/hosts/bertrand/paperclip-db.sls
@@ -1,0 +1,17 @@
+# Create the paperclip PostgreSQL database and user.
+
+paperclip-db-user:
+  postgres_user.present:
+    - name: paperclip
+    - password: "{{ salt['pillar.get']('secrets:vault:paperclip:db_password') | trim }}"
+    - encrypted: scram-sha-256
+    - login: True
+    - require:
+      - service: postgresql-service
+
+paperclip-db:
+  postgres_database.present:
+    - name: paperclip
+    - owner: paperclip
+    - require:
+      - postgres_user: paperclip-db-user

--- a/salt/hosts/bertrand/paperclip.namche.ai.conf
+++ b/salt/hosts/bertrand/paperclip.namche.ai.conf
@@ -1,0 +1,22 @@
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name paperclip.namche.ai;
+    client_max_body_size 50M;
+
+    ssl_certificate /etc/nginx/certs/namche.ai.cloudflare-origin.crt;
+    ssl_certificate_key /etc/nginx/certs/namche.ai.cloudflare-origin.key;
+    ssl_trusted_certificate /etc/nginx/certs/cloudflare-origin-ca-rsa-root.pem;
+    include conf.d/ssl.conf.inc;
+
+    location / {
+        proxy_http_version 1.1;
+        include /etc/nginx/proxy_params;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_pass http://127.0.0.1:3100;
+    }
+
+    access_log /var/log/nginx/paperclip.namche.ai.access.log;
+    error_log /var/log/nginx/paperclip.namche.ai.error.log;
+}


### PR DESCRIPTION
## Summary

- Add **paperclip** app module (`salt/apps/paperclip/`) with:
  - Git clone from `paperclipai/paperclip` repo
  - Docker Compose with local build (uses repo's Dockerfile)
  - Systemd oneshot service with `--build` on start
  - Jinja env template pulling secrets from encrypted pillar
  - Data volume at `/srv/paperclip`
- Add **paperclip-db** host state for PostgreSQL user + database (scram-sha-256)
- Wire into bertrand's init.sls includes
- Nginx already has the `paperclip.namche.ai` vhost in `namche.ai.conf`

### Required encrypted pillar entries (secrets.sls)
```
secrets:vault:paperclip:db_password
secrets:vault:paperclip:better_auth_secret
```

## Test plan
- [ ] Add encrypted secrets to pillar
- [ ] Run `salt-call --local state.apply test=True`
- [ ] Verify paperclip container builds and starts
- [ ] Verify `https://paperclip.namche.ai` loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)