### PR TITLE
bertrand: add ~/.local/bin to paperclip service PATH

### DIFF
--- a/salt/apps/paperclip/paperclip.service
+++ b/salt/apps/paperclip/paperclip.service
@@ -8,6 +8,7 @@ Type=simple
 User=deploy
 Group=deploy
 WorkingDirectory=/home/deploy/apps/paperclip
+Environment=PATH=/home/deploy/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 EnvironmentFile=/home/deploy/apps/paperclip/.env
 ExecStart=/usr/bin/node --import ./server/node_modules/tsx/dist/loader.mjs server/dist/index.js
 Restart=always


### PR DESCRIPTION
## Summary

Add `/home/deploy/.local/bin` to the systemd service PATH so paperclip can find the `claude` binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)