### PR TITLE
Install GitHub CLI on Bertrand

### DIFF
--- a/salt/github-cli/init.sls
+++ b/salt/github-cli/init.sls
@@ -1,0 +1,26 @@
+{%- if grains['os'] == 'Ubuntu' %}
+/etc/apt/keyrings:
+  file.directory:
+    - user: root
+    - group: root
+    - mode: "0755"
+
+/etc/apt/keyrings/githubcli-archive-keyring.gpg:
+  file.managed:
+    - source: https://cli.github.com/packages/githubcli-archive-keyring.gpg
+    - require:
+      - file: /etc/apt/keyrings
+
+/etc/apt/sources.list.d/github-cli.list:
+  file.managed:
+    - contents: |
+        deb [signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main
+    - require:
+      - file: /etc/apt/keyrings/githubcli-archive-keyring.gpg
+
+gh:
+  pkg.installed:
+    - refresh: True
+    - require:
+      - file: /etc/apt/sources.list.d/github-cli.list
+{%- endif %}

--- a/salt/hosts/bertrand/init.sls
+++ b/salt/hosts/bertrand/init.sls
@@ -3,6 +3,7 @@ include:
   - apps.honcho
   - apps.paperclip
   - apps.searxng
+  - github-cli
   - hosts.bertrand.deploy
   - hosts.bertrand.honcho-db
   - hosts.bertrand.paperclip-db


### PR DESCRIPTION
## Summary
- add a reusable Salt state to install GitHub CLI from the official Debian apt repository
- include that state on bertrand

## Testing
- not run locally;  is not installed in this workspace
