### PR TITLE
Add source hash for GitHub CLI keyring

### DIFF
--- a/salt/github-cli/init.sls
+++ b/salt/github-cli/init.sls
@@ -10,6 +10,7 @@ github-cli-archive-keyring:
   file.managed:
     - name: /etc/apt/keyrings/githubcli-archive-keyring.gpg
     - source: https://cli.github.com/packages/githubcli-archive-keyring.gpg
+    - source_hash: sha256=6084d5d7bd8e288441e0e94fc6275570895da18e6751f70f057485dc2d1a811b
     - require:
       - file: github-cli-apt-keyrings-dir
 


### PR DESCRIPTION
Summary:
- add the missing source_hash for the GitHub CLI apt keyring download

Why:
The Bertrand Salt Apply workflow failed on merged commit 1b96247413c0c2e0ed3e36d81988820c915af90e because Salt refused to manage https://cli.github.com/packages/githubcli-archive-keyring.gpg without a verifiable upstream hash.

Testing:
- verified the upstream SHA-256 locally with curl and shasum
- not run locally with salt-call; salt-call is not installed in this workspace
